### PR TITLE
Use environment variables for DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# FORMULARIO MULTICRITERIO
+
+Aplicación Flask que se conecta a una base de datos MySQL.
+
+## Variables de entorno necesarias
+
+Configura las siguientes variables de entorno antes de ejecutar la aplicación:
+
+- `DB_HOST`: host de la base de datos.
+- `DB_USER`: usuario de la base de datos.
+- `DB_PASSWORD`: contraseña del usuario.
+- `DB_NAME`: nombre de la base de datos.
+
+Ejemplo en Linux/Mac:
+
+```bash
+export DB_HOST=localhost
+export DB_USER=root
+export DB_PASSWORD=tu_contraseña
+export DB_NAME=sistema_formularios
+```
+
+Luego puedes iniciar la aplicación con:
+
+```bash
+python app.py
+```

--- a/db.py
+++ b/db.py
@@ -1,11 +1,13 @@
+import os
 import mysql.connector
 
 def get_connection():
+    """Create a connection to the MySQL database using environment variables."""
     return mysql.connector.connect(
-        host='localhost',
-        user='root',
-        password='wavedlizard2115',
-        database='sistema_formularios'
+        host=os.environ.get("DB_HOST"),
+        user=os.environ.get("DB_USER"),
+        password=os.environ.get("DB_PASSWORD"),
+        database=os.environ.get("DB_NAME"),
     )
 
 def get_cursor(conn):


### PR DESCRIPTION
## Summary
- fetch database credentials from environment variables instead of hardcoding
- document required DB_* variables in new README

## Testing
- `python -m py_compile db.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_688db656656083229bd8f75e54e72ec0