### PR TITLE
Add chart visualization to admin ranking page

### DIFF
--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Ranking de Factores</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 
 <body class="bg-light">
@@ -33,10 +34,39 @@
             </table>
         </div>
 
+        <canvas id="rankingChart" class="mt-4"></canvas>
+
         <div class="text-center mt-4">
             <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver al Panel</a>
         </div>
     </div>
+
+    <script>
+        const labels = {{ ranking|map(attribute='nombre')|list }};
+        const data = {{ ranking|map(attribute='total')|list }};
+
+        const ctx = document.getElementById('rankingChart').getContext('2d');
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Total Ponderado',
+                    data: data,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                scales: {
+                    y: {
+                        beginAtZero: true
+                    }
+                }
+            }
+        });
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- include Chart.js CDN and canvas element for ranking visualization
- build labels and data arrays from ranking and render bar chart

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688dba97c4fc83229ef34fd5ed61ab6e