### PR TITLE
Add PDF export to admin ranking view

### DIFF
--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -6,10 +6,11 @@
     <title>Ranking de Factores</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.2/html2pdf.bundle.min.js"></script>
 </head>
 
 <body class="bg-light">
-    <div class="container py-5">
+    <div id="rankingContent" class="container py-5">
         <h3 class="text-center mb-4">Ranking Global de Factores</h3>
 
         <div class="table-responsive">
@@ -37,6 +38,7 @@
         <canvas id="rankingChart" class="mt-4"></canvas>
 
         <div class="text-center mt-4">
+            <button id="downloadPDF" class="btn btn-primary me-2">Descargar PDF</button>
             <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver al Panel</a>
         </div>
     </div>
@@ -65,6 +67,11 @@
                     }
                 }
             }
+        });
+
+        document.getElementById('downloadPDF').addEventListener('click', () => {
+            const element = document.getElementById('rankingContent');
+            html2pdf().from(element).save('ranking.pdf');
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- allow admins to download ranking report as PDF

## Testing
- `python -m py_compile app.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_688dbd943d9083228358119e864492c9