### PR TITLE
Reemplazar estilos en línea por clases

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -705,6 +705,39 @@ h3::after {
   text-align: center;
 }
 
+/* Table header width helpers */
+.th-factores {
+  width: 25%;
+}
+
+.th-definicion {
+  width: 60%;
+}
+
+.th-ponderacion {
+  width: 15%;
+}
+
+.th-factor {
+  width: 15%;
+}
+
+.th-definicion-detalle {
+  width: 35%;
+}
+
+.th-valor-usuario {
+  width: 15%;
+}
+
+.th-ponderacion-admin {
+  width: 15%;
+}
+
+.th-valor-ponderado {
+  width: 20%;
+}
+
 .table td {
   vertical-align: middle;
 }
@@ -756,8 +789,15 @@ input[type="number"].ponderacion:focus {
 
 .valor-ponderado {
   font-weight: 600;
-  color: var(--color-primario-medio);
   min-width: 100px;
+}
+
+.texto-ponderado {
+  color: var(--color-primario-medio);
+}
+
+.texto-gris {
+  color: #6c757d;
 }
 
 .factor-name {

--- a/templates/admin_detalle.html
+++ b/templates/admin_detalle.html
@@ -24,11 +24,11 @@
                 <table class="table table-bordered table-hover">
                     <thead>
                         <tr>
-                            <th style="width: 15%">Factor</th>
-                            <th style="width: 35%">Definición</th>
-                            <th style="width: 15%">Valor Usuario</th>
-                            <th style="width: 15%">Ponderación Admin</th>
-                            <th style="width: 20%">Valor Ponderado</th>
+                            <th class="th-factor">Factor</th>
+                            <th class="th-definicion-detalle">Definición</th>
+                            <th class="th-valor-usuario">Valor Usuario</th>
+                            <th class="th-ponderacion-admin">Ponderación Admin</th>
+                            <th class="th-valor-ponderado">Valor Ponderado</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -74,13 +74,15 @@
                 const valAdmin = parseFloat(input.value);
                 const celda = fila.querySelector('.valor-ponderado');
 
+                celda.classList.remove('texto-ponderado', 'texto-gris');
+
                 if (!isNaN(valUsuario) && !isNaN(valAdmin)) {
                     const resultado = (valUsuario * valAdmin).toFixed(2);
                     celda.textContent = resultado;
-                    celda.style.color = valAdmin > 0 ? 'var(--color-primario-medio)' : '#6c757d';
+                    celda.classList.add(valAdmin > 0 ? 'texto-ponderado' : 'texto-gris');
                 } else {
                     celda.textContent = '—';
-                    celda.style.color = '#6c757d';
+                    celda.classList.add('texto-gris');
                 }
             });
         }

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -93,9 +93,9 @@
                     <table class="table table-bordered align-middle">
                         <thead>
                             <tr>
-                                <th style="width: 25%;">Factores</th>
-                                <th style="width: 60%;">Definición</th>
-                                <th style="width: 15%;">Ponderación</th>
+                                <th class="th-factores">Factores</th>
+                                <th class="th-definicion">Definición</th>
+                                <th class="th-ponderacion">Ponderación</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
## Summary
- Define CSS classes for table header widths and text colors, removing inline style attributes.
- Update HTML templates to use the new classes and streamline color handling via classList.
- Refactor admin detail script to toggle color classes instead of inline style changes.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `node test script (manual)`


------
https://chatgpt.com/codex/tasks/task_e_688dcee5b9148322ab97c7defad827b5