### PR TITLE
Add custom error pages and handlers

### DIFF
--- a/app.py
+++ b/app.py
@@ -292,6 +292,18 @@ def vista_ranking():
 
 
 # ==============================
+# ERRORES
+# ==============================
+
+@app.errorhandler(400)
+def handle_bad_request(error):
+    return render_template('error_400.html'), 400
+
+@app.errorhandler(500)
+def handle_server_error(error):
+    return render_template('error_500.html'), 500
+
+# ==============================
 # MAIN
 # ==============================
 

--- a/templates/error_400.html
+++ b/templates/error_400.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Error 400 - Solicitud incorrecta</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+</head>
+<body>
+    <div class="container py-5">
+        <div class="confirmation-card">
+            <div class="check-icon">
+                <i class="bi bi-exclamation-triangle"></i>
+            </div>
+            <h3>Error 400: Solicitud incorrecta</h3>
+            <p>La solicitud enviada no es válida.</p>
+            <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
+        </div>
+    </div>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/error_500.html
+++ b/templates/error_500.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Error 500 - Error del servidor</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+</head>
+<body>
+    <div class="container py-5">
+        <div class="confirmation-card">
+            <div class="check-icon">
+                <i class="bi bi-exclamation-triangle"></i>
+            </div>
+            <h3>Error 500: Error del servidor</h3>
+            <p>Ha ocurrido un problema inesperado.</p>
+            <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
+        </div>
+    </div>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show custom 400 and 500 error pages with shared styling
- register Flask error handlers for bad requests and server errors

## Testing
- `python -m py_compile app.py`
- `python -m pytest`
- `python app.py` *(fails: Can't connect to MySQL server on '127.0.0.1:3306')*


------
https://chatgpt.com/codex/tasks/task_e_688dd1dc22a8832289f36037d959144d