### PR TITLE
Reemplaza icono de visibilidad por checkbox

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -306,55 +306,14 @@ h2::after {
   padding: 1rem;
 }
 
-/* Contenedor mejorado para el campo de contraseña */
-.password-container {
-    position: relative;
-    margin-bottom: 1.5rem;
+.form-check-input:checked {
+  background-color: var(--color-acento);
+  border-color: var(--color-acento);
 }
 
-/* Estilo para el botón del ojo */
-.toggle-password {
-    position: absolute;
-    right: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    background: none;
-    border: none;
-    padding: 8px;
-    color: var(--color-primario-medio);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    border-radius: 50%;
-    width: 36px;
-    height: 36px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.toggle-password:hover {
-    background-color: rgba(32, 133, 140, 0.1);
-    color: var(--color-acento);
-}
-
-.toggle-password:active {
-    transform: translateY(-50%) scale(0.95);
-}
-
-.toggle-password i {
-    font-size: 1.2rem;
-    transition: all 0.2s ease;
-}
-
-/* Ajuste para el input de contraseña */
-#password {
-    padding-right: 45px; /* Más espacio para el ícono */
-    transition: all 0.3s;
-}
-
-#password:focus {
-    border-color: var(--color-acento);
-    box-shadow: 0 0 0 0.25rem rgba(32, 133, 140, 0.25);
+.form-check-label {
+  color: var(--color-primario-medio);
+  font-weight: 500;
 }
 
 .logo-container {

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -28,25 +28,22 @@
             {% endwith %}
 
             <form method="post">
-                <div class="mb-4 password-container">
+                <div class="mb-4">
                     <label for="password" class="form-label">Contraseña</label>
                     <input type="password" class="form-control" id="password" name="password" required>
-                    <button type="button" class="toggle-password" id="togglePassword" aria-label="Mostrar contraseña">
-                        <i class="bi bi-eye-fill"></i>
-                    </button>
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" id="showPassword">
+                        <label class="form-check-label" for="showPassword">Mostrar contraseña</label>
+                    </div>
                 </div>
             </form>
         </div>
     </div>
 
     <script>
-        // Mostrar/ocultar contraseña
-        document.getElementById('togglePassword').addEventListener('click', function () {
+        document.getElementById('showPassword').addEventListener('change', function () {
             const passwordInput = document.getElementById('password');
-            const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
-            passwordInput.setAttribute('type', type);
-            this.classList.toggle('bi-eye-fill');
-            this.classList.toggle('bi-eye-slash-fill');
+            passwordInput.type = this.checked ? 'text' : 'password';
         });
     </script>
 


### PR DESCRIPTION
## Summary
- Elimina el botón del ojo en el login de administrador
- Añade un checkbox para mostrar/ocultar la contraseña con script simplificado
- Actualiza estilos eliminando reglas del icono e incorporando estilos del checkbox

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- Node.js + jsdom para comprobar cambio de tipo en el input de contraseña
- `python app.py` (falla: Can't connect to MySQL server)


------
https://chatgpt.com/codex/tasks/task_e_688e79354a248322bb05093e107fa228