### PR TITLE
feat: add admin factor management

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,6 +203,28 @@ def panel_admin():
 
     return render_template('admin.html', respuestas=respuestas)
 
+
+@app.route('/admin/factores', methods=['GET', 'POST'])
+def administrar_factores():
+    if not session.get('is_admin'):
+        return redirect(url_for('admin_login'))
+
+    if request.method == 'POST':
+        for i in range(1, 11):
+            nombre = request.form.get(f'nombre_{i}')
+            descripcion = request.form.get(f'descripcion_{i}')
+            cursor.execute(
+                "UPDATE factor SET nombre=%s, descripcion=%s WHERE id=%s",
+                (nombre, descripcion, i)
+            )
+        conn.commit()
+        flash("Factores actualizados correctamente.")
+        return redirect(url_for('administrar_factores'))
+
+    cursor.execute("SELECT * FROM factor ORDER BY id")
+    factores = cursor.fetchall()
+    return render_template('admin_factores.html', factores=factores)
+
 # ==============================
 # DETALLE DE RESPUESTA (ADMIN)
 # ==============================

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -57,6 +57,7 @@
             {% endif %}
             
             <div class="action-buttons">
+                <a href="{{ url_for('administrar_factores') }}" class="btn btn-outline-primary">Editar Factores</a>
                 <a href="{{ url_for('vista_ranking') }}" class="btn btn-outline-primary">Ver Ranking Global</a>
                 <a href="{{ url_for('admin_logout') }}" class="btn btn-outline-secondary">Cerrar sesión</a>
             </div>

--- a/templates/admin_factores.html
+++ b/templates/admin_factores.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Administrar Factores</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+</head>
+
+<body>
+    <div class="container py-5">
+        <div class="admin-container">
+            <div class="logo-container">
+                <div class="logo-placeholder">Logo 1</div>
+                <div class="logo-placeholder">Logo 2</div>
+                <div class="logo-placeholder">Logo 3</div>
+            </div>
+
+            <h2>Editar Factores</h2>
+
+            <form method="POST" action="{{ url_for('administrar_factores') }}">
+                <div class="table-responsive">
+                    <table class="table table-bordered table-hover">
+                        <thead class="text-center">
+                            <tr>
+                                <th>ID</th>
+                                <th>Nombre</th>
+                                <th>Descripción</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for f in factores %}
+                            <tr>
+                                <td class="text-center">{{ f.id }}</td>
+                                <td>
+                                    <input type="text" name="nombre_{{ f.id }}" class="form-control"
+                                           value="{{ f.nombre }}">
+                                </td>
+                                <td>
+                                    <input type="text" name="descripcion_{{ f.id }}" class="form-control"
+                                           value="{{ f.descripcion }}">
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                <div class="text-center mt-3">
+                    <button type="submit" class="btn btn-primary">Guardar cambios</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+
+</html>
+


### PR DESCRIPTION
## Summary
- enable administrators to edit factor names and descriptions via new route
- add dedicated admin page for updating factors
- include navigation link from admin panel

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e81b7afc48322bbff59667aaf5152