### PR TITLE
Add admin panel return link

### DIFF
--- a/templates/admin_factores.html
+++ b/templates/admin_factores.html
@@ -46,8 +46,9 @@
                         </tbody>
                     </table>
                 </div>
-                <div class="text-center mt-3">
+                <div class="d-flex justify-content-center gap-2 mt-3">
                     <button type="submit" class="btn btn-primary">Guardar cambios</button>
+                    <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver</a>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- add Bootstrap-styled return link in admin factors view

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import db

class DummyCursor:
    def execute(self, *args, **kwargs):
        return []
    def fetchall(self):
        return []
    def fetchone(self):
        return None

class DummyConn:
    def cursor(self, dictionary=True):
        return DummyCursor()

db.get_connection = lambda: DummyConn()
from app import app
with app.test_request_context():
    print(app.url_for('panel_admin'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_688e8441e7b88322a95aca8216725c82