### PR TITLE
Add exit redirect modal for form

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,6 +102,7 @@ def mostrar_formulario(id_usuario):
 def guardar_respuesta():
     id_usuario = int(request.form['usuario_id'])
     id_formulario = int(request.form['formulario_id'])
+    exit_redirect = request.form.get('exit_redirect')
 
     # Datos personales
     nombre = request.form['nombre'].strip()
@@ -162,7 +163,8 @@ def guardar_respuesta():
             VALUES (%s, %s, %s)
         """, (id_respuesta, factor_id, valor))
     conn.commit()
-
+    if exit_redirect:
+        return redirect(url_for('index'))
     return render_template('confirmacion.html')
 
 

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -110,8 +110,7 @@
                                     <select name="valor_{{ loop.index }}" class="form-select valor-factor" required>
                                         <option value="">Seleccione</option>
                                         {% for num in range(1, 11) %}
-                                        <option value="{{ num }}" {% if respuestas_previas[factor.id]|default('')==num
-                                            %}selected{% endif %}>
+                                        <option value="{{ num }}" {% if respuestas_previas[factor.id]|default('')==num %}selected{% endif %}>
                                             {{ num }}
                                         </option>
                                         {% endfor %}
@@ -123,12 +122,61 @@
                     </table>
                 </div>
 
-                <button type="submit" class="btn btn-primary mt-4 w-100 py-3">Guardar Respuestas</button>
+                <div class="d-flex mt-4 gap-2">
+                    <button type="submit" class="btn btn-primary flex-fill py-3">Guardar Respuestas</button>
+                    <button type="button" id="backButton" class="btn btn-secondary flex-fill py-3">Regresar</button>
+                </div>
             </form>
         </div>
     </div>
 
+    <!-- Modal de confirmación al regresar -->
+    <div class="modal fade" id="exitModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">¿Desea salir?</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body">
+                    Seleccione una opción para continuar.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="modalGuardar">Guardar</button>
+                    <button type="button" class="btn btn-danger" id="modalDescartar">Descartar</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const backButton = document.getElementById('backButton');
+            const exitModal = new bootstrap.Modal(document.getElementById('exitModal'));
+            const modalGuardar = document.getElementById('modalGuardar');
+            const modalDescartar = document.getElementById('modalDescartar');
+
+            backButton.addEventListener('click', () => {
+                exitModal.show();
+            });
+
+            modalGuardar.addEventListener('click', () => {
+                const form = document.querySelector('form');
+                const hidden = document.createElement('input');
+                hidden.type = 'hidden';
+                hidden.name = 'exit_redirect';
+                hidden.value = 'true';
+                form.appendChild(hidden);
+                form.submit();
+            });
+
+            modalDescartar.addEventListener('click', () => {
+                window.location = '/';
+            });
+        });
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- add return modal to form with Guardar, Descartar, and Cancelar options
- send hidden `exit_redirect` on guarded save and redirect from backend

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eac88c2808322b14da226bdeb191e