### PR TITLE
feat: warn about pending forms in ranking

### DIFF
--- a/app.py
+++ b/app.py
@@ -313,6 +313,15 @@ def guardar_ponderacion():
 def vista_ranking():
     if not session.get('is_admin'):
         return redirect(url_for('admin_login'))
+    # Contar formularios asignados y formularios con respuesta
+    cursor.execute("SELECT COUNT(*) AS total FROM asignacion")
+    total_asignados = cursor.fetchone()["total"]
+
+    cursor.execute("SELECT COUNT(*) AS total FROM respuesta")
+    total_respuestas = cursor.fetchone()["total"]
+
+    pendientes = total_respuestas < total_asignados
+
     cursor.execute("""
         SELECT f.nombre, SUM(p.peso_admin * rd.valor_usuario) AS total
         FROM ponderacion_admin p
@@ -322,7 +331,14 @@ def vista_ranking():
         ORDER BY total DESC
     """)
     ranking = cursor.fetchall()
-    return render_template('admin_ranking.html', ranking=ranking)
+
+    return render_template(
+        'admin_ranking.html',
+        ranking=ranking,
+        pendientes=pendientes,
+        total_asignados=total_asignados,
+        total_respuestas=total_respuestas,
+    )
 
 
 # ==============================

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -24,6 +24,12 @@
 
       <h3>Ranking Global de Factores</h3>
 
+      {% if pendientes %}
+      <div class="alert alert-warning" role="alert">
+        Faltan formularios por contestar; el ranking es parcial.
+      </div>
+      {% endif %}
+
       <div class="table-responsive">
         <table class="table table-bordered table-hover text-center">
           <thead>


### PR DESCRIPTION
## Summary
- track assigned vs answered forms for admin ranking
- show alert when ranking is partial due to pending forms

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688eb2d0b2e88322ae3721c6cce559e2