### PR TITLE
Manejo de ranking vacío

### DIFF
--- a/app.py
+++ b/app.py
@@ -370,6 +370,13 @@ def vista_ranking():
         cursor.execute(ranking_query + " GROUP BY f.id ORDER BY total DESC")
     ranking = cursor.fetchall()
 
+    # Determinar si no hay datos o si todos los totales son cero
+    estado_ranking = None
+    if not ranking:
+        estado_ranking = "sin_datos"
+    elif all((row["total"] or 0) == 0 for row in ranking):
+        estado_ranking = "totales_cero"
+
     return render_template(
         'admin_ranking.html',
         ranking=ranking,
@@ -377,6 +384,7 @@ def vista_ranking():
         total_asignados=total_asignados,
         total_respuestas=total_respuestas,
         incompletas=incompletas,
+        estado_ranking=estado_ranking,
     )
 
 

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -36,6 +36,12 @@
       </div>
       {% endif %}
 
+      {% if estado_ranking %}
+      <div class="alert alert-info" role="alert">No hay ponderaciones registradas</div>
+      <div class="text-center mt-4">
+        <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver al Panel</a>
+      </div>
+      {% else %}
       <div class="table-responsive">
         <table class="table table-bordered table-hover text-center">
           <thead>
@@ -63,9 +69,11 @@
         <button id="downloadPNG" class="btn btn-primary me-2">Descargar como Imagen (PDF)</button>
         <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver al Panel</a>
       </div>
+      {% endif %}
     </div>
   </div>
 
+  {% if not estado_ranking %}
   <script>
     // Renderizar gráfico con datos desde Jinja
     const factorLabels = {{ ranking | map(attribute='nombre') | list | tojson | safe }};
@@ -122,5 +130,6 @@
       });
     });
   </script>
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Resumen
- Añade verificación en `vista_ranking` para detectar ausencia de datos o totales en cero.
- Envía bandera `estado_ranking` al template.
- Muestra mensaje de "No hay ponderaciones registradas" y oculta tabla/gráfico cuando corresponde.

## Pruebas
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688eb5db0c348322b846ba524c2cc70d