### PR TITLE
Add admin form management interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,6 +207,44 @@ def panel_admin():
     return render_template('admin.html', respuestas=respuestas)
 
 
+@app.route('/admin/formularios', methods=['GET', 'POST'])
+def administrar_formularios():
+    if not session.get('is_admin'):
+        return redirect(url_for('admin_login'))
+
+    if request.method == 'POST':
+        nombre = request.form.get('nombre', '').strip()
+        if nombre:
+            cursor.execute(
+                "INSERT INTO formulario (nombre) VALUES (%s)",
+                (nombre,),
+            )
+            conn.commit()
+            flash("Formulario creado correctamente.")
+        return redirect(url_for('administrar_formularios'))
+
+    cursor.execute(
+        """
+        SELECT f.id, f.nombre, COUNT(r.id) AS respuestas
+        FROM formulario f
+        LEFT JOIN respuesta r ON r.id_formulario = f.id
+        GROUP BY f.id, f.nombre
+        ORDER BY f.id
+        """
+    )
+    formularios = cursor.fetchall()
+
+    cursor.execute("SELECT IFNULL(MAX(id), 0) + 1 AS siguiente_id FROM formulario")
+    siguiente_id = cursor.fetchone()["siguiente_id"]
+    nombre_defecto = f"Formulario {siguiente_id:02d}"
+
+    return render_template(
+        'admin_formularios.html',
+        formularios=formularios,
+        nombre_defecto=nombre_defecto,
+    )
+
+
 @app.route('/admin/factores', methods=['GET', 'POST'])
 def administrar_factores():
     if not session.get('is_admin'):

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -58,6 +58,7 @@
             
             <div class="action-buttons">
                 <a href="{{ url_for('administrar_factores') }}" class="btn btn-outline-primary">Editar Factores</a>
+                <a href="{{ url_for('administrar_formularios') }}" class="btn btn-outline-primary">Administrar Formularios</a>
                 <a href="{{ url_for('vista_ranking') }}" class="btn btn-outline-primary">Ver Ranking Global</a>
                 <a href="{{ url_for('admin_logout') }}" class="btn btn-outline-secondary">Cerrar sesión</a>
             </div>

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Administrar Formularios</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+</head>
+
+<body>
+    <div class="container py-5">
+        <div class="admin-container">
+            <div class="logo-container">
+                <div class="logo-placeholder">Logo 1</div>
+                <div class="logo-placeholder">Logo 2</div>
+                <div class="logo-placeholder">Logo 3</div>
+            </div>
+
+            <h2>Administrar Formularios</h2>
+
+            {% if formularios %}
+            <div class="table-responsive">
+                <table class="table table-bordered table-hover">
+                    <thead class="text-center">
+                        <tr>
+                            <th>ID</th>
+                            <th>Nombre</th>
+                            <th>Respuestas</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for f in formularios %}
+                        <tr>
+                            <td class="text-center">{{ f.id }}</td>
+                            <td>{{ f.nombre }}</td>
+                            <td class="text-center">{{ f.respuestas }}</td>
+                            <td class="text-center">
+                                <form method="POST" action="{{ url_for('eliminar_formulario', id=f.id) }}" style="display:inline;">
+                                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                                </form>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <div class="alert alert-warning text-center">No hay formularios registrados.</div>
+            {% endif %}
+
+            <form method="POST" action="{{ url_for('administrar_formularios') }}" class="mt-4">
+                <div class="input-group mb-3">
+                    <input type="text" name="nombre" class="form-control" value="{{ nombre_defecto }}">
+                    <button class="btn btn-primary" type="submit">Agregar Formulario</button>
+                </div>
+            </form>
+
+            <div class="d-flex justify-content-center gap-2 mt-3">
+                <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver</a>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- Add `/admin/formularios` route to list and create forms with default names
- Provide `admin_formularios.html` template for managing forms and deletions
- Link the forms management view from the admin dashboard

## Testing
- `python -B -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688ebc8e9afc8322b14bc8f72b40e991