### PR TITLE
feat: confirm form deletion with response safeguard

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,6 +245,53 @@ def administrar_formularios():
     )
 
 
+@app.route('/admin/formularios/eliminar/<int:id>', methods=['POST'])
+def eliminar_formulario(id):
+    if not session.get('is_admin'):
+        return redirect(url_for('admin_login'))
+
+    cursor.execute(
+        "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s",
+        (id,),
+    )
+    total_respuestas = cursor.fetchone()["total"]
+
+    confirm = request.form.get('confirm')
+    expected = request.form.get('expected_count')
+
+    if total_respuestas > 0 and confirm != 'yes':
+        return render_template(
+            'confirmar_eliminacion_formulario.html',
+            id_formulario=id,
+            respuestas=total_respuestas,
+        )
+
+    if confirm == 'yes':
+        try:
+            expected = int(expected)
+        except (TypeError, ValueError):
+            expected = None
+        if expected is not None:
+            cursor.execute(
+                "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s",
+                (id,),
+            )
+            total_actual = cursor.fetchone()["total"]
+            if total_actual != expected:
+                flash("El número de respuestas cambió; operación cancelada.")
+                return redirect(url_for('administrar_formularios'))
+
+        cursor.execute("DELETE FROM respuesta WHERE id_formulario = %s", (id,))
+        cursor.execute("DELETE FROM asignacion WHERE id_formulario = %s", (id,))
+        cursor.execute("DELETE FROM formulario WHERE id = %s", (id,))
+        conn.commit()
+        flash("Formulario eliminado correctamente.")
+        return redirect(url_for('administrar_formularios'))
+
+    flash("Eliminación cancelada.")
+    return redirect(url_for('administrar_formularios'))
+
+
 @app.route('/admin/factores', methods=['GET', 'POST'])
 def administrar_factores():
     if not session.get('is_admin'):

--- a/templates/confirmar_eliminacion_formulario.html
+++ b/templates/confirmar_eliminacion_formulario.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Confirmar Eliminación</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+</head>
+
+<body>
+    <div class="container py-5">
+        <div class="admin-container text-center">
+            <div class="logo-container">
+                <div class="logo-placeholder">Logo 1</div>
+                <div class="logo-placeholder">Logo 2</div>
+                <div class="logo-placeholder">Logo 3</div>
+            </div>
+
+            <h2>Confirmar eliminación</h2>
+            <p>Se encontraron {{ respuestas }} respuestas asociadas a este formulario.
+                ¿Deseas eliminarlo de todos modos?</p>
+
+            <form method="POST" action="{{ url_for('eliminar_formulario', id=id_formulario) }}" class="d-inline">
+                <input type="hidden" name="confirm" value="yes">
+                <input type="hidden" name="expected_count" value="{{ respuestas }}">
+                <button type="submit" class="btn btn-danger">Eliminar de todos modos</button>
+            </form>
+            <a href="{{ url_for('administrar_formularios') }}" class="btn btn-secondary ms-2">Cancelar</a>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- Add admin route to delete forms with confirmation and concurrency checks
- Create confirmation template with response count and cancel option

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebe0181108322961b531c78ad14e5