### PR TITLE
Restringir asignación por usuario y manejar múltiples formularios

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,17 +52,31 @@ def formulario_redirect():
 
 @app.route('/formulario/<int:id_usuario>')
 def mostrar_formulario(id_usuario):
-    # Obtener el formulario asignado
+    # Obtener formularios asignados al usuario
     cursor.execute("""
         SELECT a.id_formulario, f.nombre AS nombre_formulario
         FROM asignacion a
         JOIN formulario f ON a.id_formulario = f.id
         WHERE a.id_usuario = %s
+        ORDER BY a.id_formulario
     """, (id_usuario,))
-    asignacion = cursor.fetchone()
+    asignaciones = cursor.fetchall()
 
-    if not asignacion:
+    if not asignaciones:
         return "No se encontró un formulario asignado."
+
+    # Elegir el primer formulario sin respuesta previa o el primero disponible
+    asignacion = None
+    for a in asignaciones:
+        cursor.execute(
+            "SELECT 1 FROM respuesta WHERE id_usuario = %s AND id_formulario = %s",
+            (id_usuario, a["id_formulario"]),
+        )
+        if not cursor.fetchone():
+            asignacion = a
+            break
+    if asignacion is None:
+        asignacion = asignaciones[0]
 
     id_formulario = asignacion['id_formulario']
 

--- a/database/modelo.sql
+++ b/database/modelo.sql
@@ -22,7 +22,7 @@ CREATE TABLE asignacion (
     id INT AUTO_INCREMENT PRIMARY KEY,
     id_usuario INT NOT NULL,
     id_formulario INT NOT NULL,
-    UNIQUE (id_usuario, id_formulario),
+    UNIQUE (id_usuario),
     FOREIGN KEY (id_usuario) REFERENCES usuario(id),
     FOREIGN KEY (id_formulario) REFERENCES formulario(id)
 );


### PR DESCRIPTION
## Summary
- Restringe las filas de `asignacion` a un único registro por usuario mediante `UNIQUE (id_usuario)`
- Ajusta `mostrar_formulario` para seleccionar el primer formulario sin respuesta o el primero disponible cuando hay múltiples asignaciones

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688ed24e51ec83228bb0de93677ee844