### PR TITLE
Enforce uniqueness of respuestas per user and form

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,12 +167,17 @@ def guardar_respuesta():
         return redirect(url_for('mostrar_formulario', id_usuario=id_usuario))
 
     # 4. Insertar nueva respuesta
-    cursor.execute("""
-        INSERT INTO respuesta (id_usuario, id_formulario)
-        VALUES (%s, %s)
-    """, (id_usuario, id_formulario))
-    conn.commit()
-    id_respuesta = cursor.lastrowid
+    try:
+        cursor.execute("""
+            INSERT INTO respuesta (id_usuario, id_formulario)
+            VALUES (%s, %s)
+        """, (id_usuario, id_formulario))
+        conn.commit()
+        id_respuesta = cursor.lastrowid
+    except mysql.connector.IntegrityError:
+        conn.rollback()
+        flash("Ya se registró una respuesta para este formulario.")
+        return redirect(url_for('mostrar_formulario', id_usuario=id_usuario))
 
     # 5. Insertar detalle de factores
     for factor_id, valor in valores:

--- a/database/modelo.sql
+++ b/database/modelo.sql
@@ -41,7 +41,8 @@ CREATE TABLE respuesta (
     id_formulario INT NOT NULL,
     fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (id_usuario) REFERENCES usuario(id),
-    FOREIGN KEY (id_formulario) REFERENCES formulario(id)
+    FOREIGN KEY (id_formulario) REFERENCES formulario(id),
+    UNIQUE (id_usuario, id_formulario)
 );
 
 -- Detalle de las respuestas por factor (valor de 1 a 10, sin repetir por respuesta)


### PR DESCRIPTION
## Summary
- avoid duplicate `respuesta` entries by adding unique constraint in schema
- handle duplicate submissions in `guardar_respuesta` with IntegrityError catch

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688ed47012548322b9bbb39d9acba3b8