### PR TITLE
Implement pagination for admin panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,16 +231,28 @@ def admin_logout():
 def panel_admin():
     if not session.get('is_admin'):
         return redirect(url_for('admin_login'))
-    g.cursor.execute("""
+    page = request.args.get('page', 1, type=int)
+    per_page = 10
+    offset = (page - 1) * per_page
+    g.cursor.execute(
+        """
         SELECT r.id AS id_respuesta, u.nombre, u.apellidos, f.nombre AS formulario, r.fecha_respuesta
         FROM respuesta r
         JOIN usuario u ON r.id_usuario = u.id
         JOIN formulario f ON r.id_formulario = f.id
         ORDER BY r.fecha_respuesta DESC
-    """)
+        LIMIT %s OFFSET %s
+        """,
+        (per_page + 1, offset),
+    )
     respuestas = g.cursor.fetchall()
+    has_next = len(respuestas) > per_page
+    if has_next:
+        respuestas = respuestas[:-1]
 
-    return render_template('admin.html', respuestas=respuestas)
+    return render_template(
+        'admin.html', respuestas=respuestas, page=page, has_next=has_next
+    )
 
 
 @app.route('/admin/formularios', methods=['GET', 'POST'])

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -52,6 +52,16 @@
                     </tbody>
                 </table>
             </div>
+            <div class="d-flex justify-content-between my-3">
+                {% if page > 1 %}
+                <a href="{{ url_for('panel_admin', page=page-1) }}" class="btn btn-outline-primary">Anterior</a>
+                {% else %}
+                <span></span>
+                {% endif %}
+                {% if has_next %}
+                <a href="{{ url_for('panel_admin', page=page+1) }}" class="btn btn-outline-primary">Siguiente</a>
+                {% endif %}
+            </div>
             {% else %}
             <div class="alert alert-warning text-center">Aún no hay respuestas registradas.</div>
             {% endif %}


### PR DESCRIPTION
## Summary
- Paginate admin response list using LIMIT/OFFSET based on page query parameter
- Add Previous/Next navigation controls to admin panel template

## Testing
- `python -m pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688ee626a1dc83229baaa735579e61a7