### PR TITLE
Format admin response date via SQL

### DIFF
--- a/app.py
+++ b/app.py
@@ -260,7 +260,12 @@ def panel_admin():
     offset = (page - 1) * per_page
     g.cursor.execute(
         """
-        SELECT r.id AS id_respuesta, u.nombre, u.apellidos, f.nombre AS formulario, r.fecha_respuesta
+        SELECT r.id AS id_respuesta,
+               u.nombre,
+               u.apellidos,
+               f.nombre AS formulario,
+               r.fecha_respuesta,
+               DATE_FORMAT(r.fecha_respuesta, '%Y-%m-%d %H:%i') AS fecha_respuesta_fmt
         FROM respuesta r
         JOIN usuario u ON r.id_usuario = u.id
         JOIN formulario f ON r.id_formulario = f.id

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -40,7 +40,13 @@
                             <td>{{ r.nombre }}</td>
                             <td>{{ r.apellidos }}</td>
                             <td>{{ r.formulario }}</td>
-                            <td class="text-center">{{ r.fecha_respuesta.strftime('%Y-%m-%d %H:%M') }}</td>
+                            <td class="text-center">
+                                {% if r.get('fecha_respuesta') %}
+                                    {{ r.fecha_respuesta_fmt }}
+                                {% else %}
+                                    Fecha no disponible
+                                {% endif %}
+                            </td>
                             <td class="text-center">
                                 <a href="{{ url_for('detalle_respuesta', id_respuesta=r.id_respuesta) }}"
                                     class="btn btn-sm btn-primary">


### PR DESCRIPTION
## Summary
- format response date directly in SQL for admin panel
- display formatted date in admin view and handle missing values

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688ef65dbcfc83228cc9ac403fb922e0