### PR TITLE
Parametrize ranking query and add tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -534,15 +534,14 @@ def vista_ranking():
         incompletas = RANKING_CACHE["incompletas"]
     else:
         # Detectar respuestas con ponderaciones incompletas
-        g.cursor.execute(
-            """
+        incompletas_query = """
             SELECT r.id AS id_respuesta
             FROM respuesta r
             LEFT JOIN ponderacion_admin p ON r.id = p.id_respuesta
             GROUP BY r.id
-            HAVING COUNT(p.id_factor) < 10
-            """
-        )
+            HAVING COUNT(p.id_factor) < %s
+        """
+        g.cursor.execute(incompletas_query, (10,))
         incompletas_rows = g.cursor.fetchall()
         incompletas = [row["id_respuesta"] for row in incompletas_rows]
 
@@ -556,14 +555,14 @@ def vista_ranking():
                 FROM respuesta r
                 LEFT JOIN ponderacion_admin pa2 ON r.id = pa2.id_respuesta
                 GROUP BY r.id
-                HAVING COUNT(pa2.id_factor) < 10
+                HAVING COUNT(pa2.id_factor) < %s
             ) p ON pa.id_respuesta = p.id_respuesta
             LEFT JOIN respuesta_detalle rd
                 ON rd.id_respuesta = pa.id_respuesta AND rd.id_factor = f.id
             WHERE p.id_respuesta IS NULL
             GROUP BY f.id ORDER BY total DESC
         """
-        g.cursor.execute(ranking_query)
+        g.cursor.execute(ranking_query, (10,))
         ranking = g.cursor.fetchall()
 
         RANKING_CACHE["data"] = ranking

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,74 @@
+import os
+import types
+import pytest
+
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import db
+import app as app_module
+
+app = app_module.app
+RANKING_CACHE = app_module.RANKING_CACHE
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+        self.fetchone_results = [
+            {"total": 1},  # total_asignados
+            {"total": 1},  # total_respuestas
+        ]
+        self.fetchall_results = [
+            [],  # incompletas_rows
+            [{"nombre": "Factor X", "total": 5}],  # ranking
+        ]
+
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+
+    def fetchone(self):
+        return self.fetchone_results.pop(0)
+
+    def fetchall(self):
+        return self.fetchall_results.pop(0)
+
+    def close(self):
+        pass
+
+class DummyConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, dictionary=True):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+def test_vista_ranking_parametrized(monkeypatch):
+    cursor = DummyCursor()
+    conn = DummyConnection(cursor)
+    monkeypatch.setattr(db, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+
+    # reset cache
+    RANKING_CACHE["data"] = None
+    RANKING_CACHE["timestamp"] = 0
+    RANKING_CACHE["incompletas"] = None
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["is_admin"] = True
+        resp = client.get("/admin/ranking")
+        assert resp.status_code == 200
+        assert b"Factor X" in resp.data
+
+    # verify queries used placeholders
+    # queries: total_asignados, total_respuestas, incompletas, ranking
+    incompletas_query, incompletas_params = cursor.queries[2]
+    ranking_query, ranking_params = cursor.queries[3]
+    assert "HAVING COUNT(p.id_factor) < %s" in incompletas_query
+    assert incompletas_params == (10,)
+    assert "HAVING COUNT(pa2.id_factor) < %s" in ranking_query
+    assert ranking_params == (10,)


### PR DESCRIPTION
## Summary
- Parameterized ranking and incompletes SQL in `vista_ranking` to use placeholders
- Added unit test verifying ranking uses parametrized queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f038e03608322b656d0bc86b7b2df