### PR TITLE
Add Bootstrap Icons to admin and form templates

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Panel del Administrador</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 

--- a/templates/admin_factores.html
+++ b/templates/admin_factores.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Administrar Factores</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Administrar Formularios</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 

--- a/templates/confirmar_eliminacion_formulario.html
+++ b/templates/confirmar_eliminacion_formulario.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Confirmar Eliminación</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Formulario de Evaluación</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <script>
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- load Bootstrap Icons CDN in admin and form templates

## Testing
- `pytest`
- Rendered templates to confirm Bootstrap Icons link present

------
https://chatgpt.com/codex/tasks/task_e_688f22b55fe88322b89c21d298f28a06