### PR TITLE
Move Bootstrap Icons link to head sections

### DIFF
--- a/templates/confirmacion.html
+++ b/templates/confirmacion.html
@@ -5,6 +5,7 @@
     <title>Confirmación de Envío</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
 <body>
     <div class="container py-5">
@@ -28,8 +29,6 @@
         </div>
     </div>
 
-    <!-- Bootstrap Icons -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/error_400.html
+++ b/templates/error_400.html
@@ -5,6 +5,7 @@
     <title>Error 400 - Solicitud incorrecta</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
 <body>
     <div class="container py-5">
@@ -17,7 +18,6 @@
             <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
         </div>
     </div>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/error_404.html
+++ b/templates/error_404.html
@@ -5,6 +5,7 @@
     <title>Error 404 - Solicitud no encontrada</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
 <body>
     <div class="container py-5">
@@ -17,7 +18,6 @@
             <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
         </div>
     </div>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/error_500.html
+++ b/templates/error_500.html
@@ -5,6 +5,7 @@
     <title>Error 500 - Error del servidor</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
 <body>
     <div class="container py-5">
@@ -17,7 +18,6 @@
             <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
         </div>
     </div>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Move Bootstrap Icons link into head for confirmation and error templates

## Testing
- `python - <<'PY'
from app import app
from flask import render_template

for tpl in ['confirmacion.html','error_400.html','error_404.html','error_500.html']:
    with app.test_request_context('/'):
        html = render_template(tpl)
        bi_present = 'bi-' in html
        link_in_head = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css"' in html.split('</head>')[0]
        print(tpl, 'icon classes found:', bi_present, 'link in head:', link_in_head)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f24121ce88322abec644f0a874453