### PR TITLE
Add Bootstrap icons to admin views

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -74,10 +74,18 @@
             {% endif %}
             
             <div class="action-buttons">
-                <a href="{{ url_for('administrar_factores') }}" class="btn btn-outline-primary">Editar Factores</a>
-                <a href="{{ url_for('administrar_formularios') }}" class="btn btn-outline-primary">Administrar Formularios</a>
-                <a href="{{ url_for('vista_ranking') }}" class="btn btn-outline-primary">Ver Ranking Global</a>
-                <a href="{{ url_for('admin_logout') }}" class="btn btn-outline-secondary">Cerrar sesión</a>
+                <a href="{{ url_for('administrar_factores') }}" class="btn btn-outline-primary">
+                    <i class="bi bi-pencil-square me-1"></i>Editar Factores
+                </a>
+                <a href="{{ url_for('administrar_formularios') }}" class="btn btn-outline-primary">
+                    <i class="bi bi-ui-checks-grid me-1"></i>Administrar Formularios
+                </a>
+                <a href="{{ url_for('vista_ranking') }}" class="btn btn-outline-primary">
+                    <i class="bi bi-bar-chart-line me-1"></i>Ver Ranking Global
+                </a>
+                <a href="{{ url_for('admin_logout') }}" class="btn btn-outline-secondary">
+                    <i class="bi bi-box-arrow-right me-1"></i>Cerrar sesión
+                </a>
             </div>
         </div>
     </div>

--- a/templates/admin_factores.html
+++ b/templates/admin_factores.html
@@ -47,10 +47,14 @@
                         </tbody>
                     </table>
                 </div>
-                <div class="d-flex justify-content-center gap-2 mt-3">
-                    <button type="submit" class="btn btn-primary">Guardar cambios</button>
-                    <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver</a>
-                </div>
+                  <div class="d-flex justify-content-center gap-2 mt-3">
+                      <button type="submit" class="btn btn-primary">
+                          <i class="bi bi-save me-1"></i>Guardar cambios
+                      </button>
+                      <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">
+                          <i class="bi bi-arrow-left me-1"></i>Volver
+                      </a>
+                  </div>
             </form>
         </div>
     </div>

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -39,7 +39,9 @@
                             <td class="text-center">{{ f.respuestas }}</td>
                             <td class="text-center">
                                 <form method="POST" action="{{ url_for('eliminar_formulario', id=f.id) }}" style="display:inline;">
-                                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                                    <button type="submit" class="btn btn-sm btn-danger">
+                                        <i class="bi bi-trash me-1"></i>Eliminar
+                                    </button>
                                 </form>
                             </td>
                         </tr>
@@ -55,14 +57,18 @@
                 <div class="mb-3">
                     <div class="input-group">
                         <input type="text" name="nombre" class="form-control" value="{{ default_name }}" aria-describedby="nombreHelp">
-                        <button class="btn btn-primary" type="submit">Agregar Formulario</button>
+                        <button class="btn btn-primary" type="submit">
+                            <i class="bi bi-plus-circle me-1"></i>Agregar Formulario
+                        </button>
                     </div>
                     <div id="nombreHelp" class="form-text">Puedes cambiar este nombre antes de crear el formulario.</div>
                 </div>
             </form>
 
             <div class="d-flex justify-content-center gap-2 mt-3">
-                <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver</a>
+                <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">
+                    <i class="bi bi-arrow-left me-1"></i>Volver
+                </a>
             </div>
         </div>
     </div>

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -37,8 +37,12 @@
                     </div>
                 </div>
                 <div class="action-buttons">
-                    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">Volver</a>
-                    <button type="submit" class="btn btn-primary">Ingresar</button>
+                    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">
+                        <i class="bi bi-arrow-left me-1"></i>Volver
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-box-arrow-in-right me-1"></i>Ingresar
+                    </button>
                 </div>
             </form>
         </div>

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -39,7 +39,9 @@
       {% if estado_ranking %}
       <div class="alert alert-info" role="alert">No hay ponderaciones registradas</div>
       <div class="text-center mt-4">
-        <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver al Panel</a>
+        <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">
+          <i class="bi bi-arrow-left me-1"></i>Volver al Panel
+        </a>
       </div>
       {% else %}
       <div class="table-responsive">
@@ -72,8 +74,12 @@
       <canvas id="rankingChart" class="mt-4"></canvas>
 
       <div class="text-center mt-4">
-        <button id="downloadPNG" class="btn btn-primary me-2">Descargar como Imagen (PDF)</button>
-        <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">Volver al Panel</a>
+        <button id="downloadPNG" class="btn btn-primary me-2">
+          <i class="bi bi-download me-1"></i>Descargar como Imagen (PDF)
+        </button>
+        <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">
+          <i class="bi bi-arrow-left me-1"></i>Volver al Panel
+        </a>
       </div>
       {% endif %}
     </div>

--- a/templates/confirmacion.html
+++ b/templates/confirmacion.html
@@ -25,7 +25,9 @@
             <h3>¡Formulario enviado exitosamente!</h3>
             <p>Gracias por tu participación. Tus respuestas han sido registradas correctamente.</p>
             
-            <a href="{{ url_for('index') }}" class="btn btn-primary">Volver a la página principal</a>
+            <a href="{{ url_for('index') }}" class="btn btn-primary">
+                <i class="bi bi-house me-1"></i>Volver a la página principal
+            </a>
         </div>
     </div>
 

--- a/templates/confirmar_eliminacion_formulario.html
+++ b/templates/confirmar_eliminacion_formulario.html
@@ -25,9 +25,13 @@
             <form method="POST" action="{{ url_for('eliminar_formulario', id=id_formulario) }}" class="d-inline">
                 <input type="hidden" name="confirm" value="yes">
                 <input type="hidden" name="expected_count" value="{{ respuestas }}">
-                <button type="submit" class="btn btn-danger">Eliminar de todos modos</button>
+                <button type="submit" class="btn btn-danger">
+                    <i class="bi bi-trash me-1"></i>Eliminar de todos modos
+                </button>
             </form>
-            <a href="{{ url_for('administrar_formularios') }}" class="btn btn-secondary ms-2">Cancelar</a>
+            <a href="{{ url_for('administrar_formularios') }}" class="btn btn-secondary ms-2">
+                <i class="bi bi-x-circle me-1"></i>Cancelar
+            </a>
         </div>
     </div>
 

--- a/templates/error_400.html
+++ b/templates/error_400.html
@@ -15,7 +15,9 @@
             </div>
             <h3>Error 400: Solicitud incorrecta</h3>
             <p>La solicitud enviada no es válida.</p>
-            <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
+            <a href="{{ url_for('index') }}" class="btn btn-primary">
+                <i class="bi bi-arrow-left me-1"></i>Volver al inicio
+            </a>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/templates/error_404.html
+++ b/templates/error_404.html
@@ -15,7 +15,9 @@
             </div>
             <h3>Error 404: Solicitud no encontrada</h3>
             <p>La solicitud enviada no es válida.</p>
-            <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
+            <a href="{{ url_for('index') }}" class="btn btn-primary">
+                <i class="bi bi-arrow-left me-1"></i>Volver al inicio
+            </a>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/templates/error_500.html
+++ b/templates/error_500.html
@@ -15,7 +15,9 @@
             </div>
             <h3>Error 500: Error del servidor</h3>
             <p>Ha ocurrido un problema inesperado.</p>
-            <a href="{{ url_for('index') }}" class="btn btn-primary">Volver al inicio</a>
+            <a href="{{ url_for('index') }}" class="btn btn-primary">
+                <i class="bi bi-arrow-left me-1"></i>Volver al inicio
+            </a>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -124,8 +124,12 @@
                 </div>
 
                 <div class="d-flex mt-4 gap-2">
-                    <button type="submit" class="btn btn-primary flex-fill py-3">Guardar Respuestas</button>
-                    <button type="button" id="backButton" class="btn btn-secondary flex-fill py-3">Regresar</button>
+                    <button type="submit" class="btn btn-primary flex-fill py-3">
+                        <i class="bi bi-save me-1"></i>Guardar Respuestas
+                    </button>
+                    <button type="button" id="backButton" class="btn btn-secondary flex-fill py-3">
+                        <i class="bi bi-arrow-left me-1"></i>Regresar
+                    </button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- add Bootstrap icons to admin dashboard links
- include icons on form management, login, ranking, confirmation and error pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f25f7d844832299e3e60230ac570c