### PR TITLE
Invalidate ranking cache after updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,13 @@ RANKING_CACHE = {"data": None, "incompletas": None, "timestamp": 0}
 CACHE_TTL = 300  # 5 minutos
 
 
+def invalidate_ranking_cache():
+    """Reset ranking cache to force recomputation on next request."""
+    RANKING_CACHE["data"] = None
+    RANKING_CACHE["incompletas"] = None
+    RANKING_CACHE["timestamp"] = 0
+
+
 @app.before_request
 def before_request():
     g.conn = get_connection()
@@ -230,6 +237,7 @@ def guardar_respuesta():
         detalles,
     )
     g.conn.commit()
+    invalidate_ranking_cache()
     if exit_redirect:
         return redirect(url_for("index"))
     return render_template("confirmacion.html")
@@ -502,6 +510,7 @@ def guardar_ponderacion():
             ponderaciones,
         )
     g.conn.commit()
+    invalidate_ranking_cache()
 
     flash("Ponderaciones guardadas correctamente.")
     return redirect(url_for("detalle_respuesta", id_respuesta=id_respuesta))

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -12,19 +12,24 @@ app = app_module.app
 RANKING_CACHE = app_module.RANKING_CACHE
 
 class DummyCursor:
-    def __init__(self):
+    def __init__(self, fetchone_results=None, fetchall_results=None):
         self.queries = []
-        self.fetchone_results = [
+        self.execute_count = 0
+        self.fetchone_results = fetchone_results if fetchone_results is not None else [
             {"total": 1},  # total_asignados
             {"total": 1},  # total_respuestas
         ]
-        self.fetchall_results = [
+        self.fetchall_results = fetchall_results if fetchall_results is not None else [
             [],  # incompletas_rows
             [{"nombre": "Factor X", "total": 5}],  # ranking
         ]
 
     def execute(self, query, params=None):
+        self.execute_count += 1
         self.queries.append((query, params))
+
+    def executemany(self, query, seq_params):
+        self.queries.append((query, seq_params))
 
     def fetchone(self):
         return self.fetchone_results.pop(0)
@@ -35,12 +40,19 @@ class DummyCursor:
     def close(self):
         pass
 
+    def reset(self):
+        self.queries = []
+        self.execute_count = 0
+
 class DummyConnection:
     def __init__(self, cursor):
         self._cursor = cursor
 
     def cursor(self, dictionary=True):
         return self._cursor
+
+    def commit(self):
+        pass
 
     def close(self):
         pass
@@ -72,3 +84,46 @@ def test_vista_ranking_parametrized(monkeypatch):
     assert incompletas_params == (10,)
     assert "HAVING COUNT(pa2.id_factor) < %s" in ranking_query
     assert ranking_params == (10,)
+
+
+def test_ranking_cache_invalidation_after_ponderacion(monkeypatch):
+    fetchone_results = [
+        {"total": 1}, {"total": 1},
+        {"total": 1}, {"total": 1},
+        {"total": 1}, {"total": 1},
+    ]
+    fetchall_results = [
+        [], [{"nombre": "Factor X", "total": 5}],
+        [], [{"nombre": "Factor X", "total": 5}],
+    ]
+    cursor = DummyCursor(fetchone_results=fetchone_results, fetchall_results=fetchall_results)
+    conn = DummyConnection(cursor)
+    monkeypatch.setattr(db, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+
+    app_module.RANKING_CACHE["data"] = None
+    app_module.RANKING_CACHE["timestamp"] = 0
+    app_module.RANKING_CACHE["incompletas"] = None
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["is_admin"] = True
+
+        cursor.reset()
+        resp = client.get("/admin/ranking")
+        assert resp.status_code == 200
+        assert cursor.execute_count == 4
+
+        cursor.reset()
+        resp = client.get("/admin/ranking")
+        assert resp.status_code == 200
+        assert cursor.execute_count == 2
+
+        cursor.reset()
+        resp = client.post("/admin/ponderar", data={"id_respuesta": "1", "ponderacion_1": "1"})
+        assert resp.status_code == 302
+
+        cursor.reset()
+        resp = client.get("/admin/ranking")
+        assert resp.status_code == 200
+        assert cursor.execute_count == 4


### PR DESCRIPTION
## Summary
- add utility to reset ranking cache
- invalidate cache after saving weights or responses
- test ranking cache refresh when saving new weights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f2aa0111883229a8bb69b33f119b2