### PR TITLE
Add background image and update logos across pages

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -14,9 +14,15 @@
         <div class="admin-container">
             <!-- Espacio para los 3 logos -->
             <div class="logo-container">
-                <div class="logo-placeholder">Logo 1</div>
-                <div class="logo-placeholder">Logo 2</div>
-                <div class="logo-placeholder">Logo 3</div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+                </div>
             </div>
             
             <h2>Panel del Administrador</h2>

--- a/templates/admin_factores.html
+++ b/templates/admin_factores.html
@@ -13,9 +13,15 @@
     <div class="container py-5">
         <div class="admin-container">
             <div class="logo-container">
-                <div class="logo-placeholder">Logo 1</div>
-                <div class="logo-placeholder">Logo 2</div>
-                <div class="logo-placeholder">Logo 3</div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+                </div>
             </div>
 
             <h2>Editar Factores</h2>

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -13,9 +13,15 @@
     <div class="container py-5">
         <div class="admin-container">
             <div class="logo-container">
-                <div class="logo-placeholder">Logo 1</div>
-                <div class="logo-placeholder">Logo 2</div>
-                <div class="logo-placeholder">Logo 3</div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+                </div>
             </div>
 
             <h2>Administrar Formularios</h2>

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -14,9 +14,15 @@
         <div class="login-admin-card mx-auto">
             <!-- Logos -->
             <div class="logo-container">
-                <div class="logo-placeholder">Logo 1</div>
-                <div class="logo-placeholder">Logo 2</div>
-                <div class="logo-placeholder">Logo 3</div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+                </div>
             </div>
 
             <h2>Acceso Administrador</h2>

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -17,9 +17,15 @@
   <div class="container py-5">
     <div id="rankingContent">
       <div class="logo-container">
-        <div class="logo-placeholder">Logo 1</div>
-        <div class="logo-placeholder">Logo 2</div>
-        <div class="logo-placeholder">Logo 3</div>
+        <div class="logo-img-container">
+          <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+        </div>
+        <div class="logo-img-container">
+          <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+        </div>
+        <div class="logo-img-container">
+          <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+        </div>
       </div>
 
       <h3>Ranking Global de Factores</h3>

--- a/templates/confirmacion.html
+++ b/templates/confirmacion.html
@@ -12,9 +12,15 @@
         <div class="confirmation-card">
             <!-- Logos -->
             <div class="logo-container">
-                <div class="logo-placeholder">Logo 1</div>
-                <div class="logo-placeholder">Logo 2</div>
-                <div class="logo-placeholder">Logo 3</div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+                </div>
             </div>
             
             <!-- Icono de confirmación -->

--- a/templates/confirmar_eliminacion_formulario.html
+++ b/templates/confirmar_eliminacion_formulario.html
@@ -13,9 +13,15 @@
     <div class="container py-5">
         <div class="admin-container text-center">
             <div class="logo-container">
-                <div class="logo-placeholder">Logo 1</div>
-                <div class="logo-placeholder">Logo 2</div>
-                <div class="logo-placeholder">Logo 3</div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+                </div>
             </div>
 
             <h2>Confirmar eliminación</h2>

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -45,9 +45,15 @@
         <div class="evaluation-card">
             <!-- Espacio para los 3 logos -->
             <div class="logo-container">
-                <div class="logo-placeholder">Logo 1</div>
-                <div class="logo-placeholder">Logo 2</div>
-                <div class="logo-placeholder">Logo 3</div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+                </div>
+                <div class="logo-img-container">
+                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+                </div>
             </div>
             
             <h2>Formulario de Evaluación Multicriterio</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,12 @@
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    <style>
+        body {
+            background: url("{{ url_for('static', filename='img/background.png') }}") no-repeat center center fixed;
+            background-size: cover;
+        }
+    </style>
 </head>
 
 <body>
@@ -23,13 +29,13 @@
                 <!-- Espacio para los 3 logos -->
                 <div class="logo-container">
                     <div class="logo-img-container">
-                        <img src="static/img/logo_unam.png" alt="Logo UNAM">
+                        <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
                     </div>
                     <div class="logo-img-container">
-                        <img src="static/img/logo_fes.png" alt="Logo FES">
+                        <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
                     </div>
                     <div class="logo-img-container">
-                        <img src="static/img/logo_planeacion.png" alt="Logo Planeación">
+                        <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- Apply a full-page background image on the landing page.
- Replace placeholder logos with UNAM, FES and Planeación images across administrator and user templates.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3184cb9c8322a21a9cebb6566103