### PR TITLE
feat: admin reset of all forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -389,6 +389,20 @@ def eliminar_formulario(id):
     return redirect(url_for("administrar_formularios"))
 
 
+@app.route("/admin/formularios/reiniciar", methods=["POST"])
+def reiniciar_formularios():
+    if not session.get("is_admin"):
+        return redirect(url_for("admin_login"))
+
+    g.cursor.execute("DELETE FROM ponderacion_admin")
+    g.cursor.execute("DELETE FROM respuesta_detalle")
+    g.cursor.execute("DELETE FROM respuesta")
+    g.conn.commit()
+    invalidate_ranking_cache()
+    flash("Todos los formularios han sido reiniciados.")
+    return redirect(url_for("administrar_formularios"))
+
+
 @app.route("/admin/factores", methods=["GET", "POST"])
 def administrar_factores():
     if not session.get("is_admin"):

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -75,7 +75,28 @@
                 <a href="{{ url_for('panel_admin') }}" class="btn btn-secondary">
                     <i class="bi bi-arrow-left me-1"></i>Volver
                 </a>
+                <button type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#resetModal">
+                    <i class="bi bi-arrow-clockwise me-1"></i>Reiniciar Formularios
+                </button>
             </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="resetModal" tabindex="-1" aria-labelledby="resetModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <form method="POST" action="{{ url_for('reiniciar_formularios') }}" class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="resetModalLabel">Confirmar Reinicio</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body">
+                    <p>¿Estás seguro de que deseas reiniciar todos los formularios? Esta acción eliminará todas las respuestas y ponderaciones.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-danger">Reiniciar</button>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/tests/test_admin_formularios.py
+++ b/tests/test_admin_formularios.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import db
+import app as app_module
+
+app = app_module.app
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+    def close(self):
+        pass
+
+class DummyConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.commit_called = False
+    def cursor(self, dictionary=True):
+        return self._cursor
+    def commit(self):
+        self.commit_called = True
+    def close(self):
+        pass
+
+
+def create_dummy(monkeypatch):
+    cursor = DummyCursor()
+    conn = DummyConnection(cursor)
+    monkeypatch.setattr(db, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+    return cursor, conn
+
+
+def test_reiniciar_formularios_requires_admin(monkeypatch):
+    cursor, conn = create_dummy(monkeypatch)
+    with app.test_client() as client:
+        resp = client.post("/admin/formularios/reiniciar")
+        assert resp.status_code == 302
+        assert "/admin/login" in resp.headers["Location"]
+        assert cursor.queries == []
+
+
+def test_reiniciar_formularios(monkeypatch):
+    cursor, conn = create_dummy(monkeypatch)
+    app_module.RANKING_CACHE["data"] = "x"
+    app_module.RANKING_CACHE["incompletas"] = "y"
+    app_module.RANKING_CACHE["timestamp"] = 123
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["is_admin"] = True
+        resp = client.post("/admin/formularios/reiniciar")
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/admin/formularios")
+
+    assert cursor.queries == [
+        ("DELETE FROM ponderacion_admin", None),
+        ("DELETE FROM respuesta_detalle", None),
+        ("DELETE FROM respuesta", None),
+    ]
+    assert conn.commit_called
+    assert app_module.RANKING_CACHE["data"] is None
+    assert app_module.RANKING_CACHE["incompletas"] is None
+    assert app_module.RANKING_CACHE["timestamp"] == 0


### PR DESCRIPTION
## Summary
- add `/admin/formularios/reiniciar` route to wipe answers and cache
- add UI button and confirmation modal to trigger reset
- test reset route access, query sequence and redirect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f38389ef88322a85b16b53aac3819