### PR TITLE
Add user instructions modal list

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -66,8 +66,24 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <!-- Espacio reservado para las instrucciones -->
-                    <!-- Las instrucciones se incluirán posteriormente aquí -->
+                    <ol class="list-group list-group-numbered">
+                        <li class="list-group-item my-4">
+                            Ingresa tu ID de usuario y presiona <strong>Ingresar al Formulario</strong>.
+                            <div class="text-center my-3"><!-- Imagen del paso 1 --></div>
+                        </li>
+                        <li class="list-group-item my-4">
+                            Verifica tus datos y asigna valores únicos del 10 al 1 a cada factor.
+                            <div class="text-center my-3"><!-- Imagen del paso 2 --></div>
+                        </li>
+                        <li class="list-group-item my-4">
+                            Presiona <strong>Guardar Respuestas</strong> y confirma la acción en el modal.
+                            <div class="text-center my-3"><!-- Imagen del paso 3 --></div>
+                        </li>
+                        <li class="list-group-item my-4">
+                            Revisa la página de confirmación y regresa al inicio si es necesario.
+                            <div class="text-center my-3"><!-- Imagen del paso 4 --></div>
+                        </li>
+                    </ol>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Entendido</button>


### PR DESCRIPTION
## Summary
- Replace instruction placeholder in index modal with ordered list steps and image placeholders.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f44a6b75083229dbade5f3728e76e