### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -649,6 +649,17 @@ input[type="number"].ponderacion:focus {
   }
 }
 
+@media (max-width: 576px) {
+  .evaluation-card {
+    padding: 1.5rem;
+  }
+
+  .logo-img-container {
+    width: 60px;
+    height: 60px;
+  }
+}
+
 /* Estilo para el grupo de entrada */
 .input-group {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- tweak evaluation card and logo scaling for small screens
- add responsive CSS for phones <576px

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc4feb0e883229978737347bcad6d