### PR TITLE
feat: add Poppins font

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
+
 /* Shared styles */
 :root {
   --color-primario-oscuro: #74560f;
@@ -10,6 +12,7 @@
 body {
   background: linear-gradient(135deg, var(--color-claro-1), var(--color-claro-2));
   min-height: 100vh;
+  font-family: 'Poppins', sans-serif;
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- load Poppins font from Google Fonts
- use Poppins as default body font

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe4d2ba748322ba1c10f441bfff86