### PR TITLE
Move admin navbar outside container

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -126,7 +126,11 @@ h2::after {
   border-radius: 15px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
   padding: 2.5rem;
-  margin: 2rem auto;
+  margin: 0 auto 2rem;
+}
+
+.admin-navbar {
+  margin-bottom: 2rem;
 }
 
 .table thead th {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -12,6 +12,23 @@
 
 <body>
     <div class="container py-5">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light admin-navbar">
+          <div class="container-fluid">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false"
+                    aria-label="Toggle navigation">
+              <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="adminNav">
+              <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('administrar_factores') }}"><i class="bi bi-pencil-square me-1"></i>Editar Factores</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('administrar_formularios') }}"><i class="bi bi-ui-checks-grid me-1"></i>Administrar Formularios</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('vista_ranking') }}"><i class="bi bi-bar-chart-line me-1"></i>Ver Ranking Global</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_logout') }}"><i class="bi bi-box-arrow-right me-1"></i>Cerrar sesión</a></li>
+              </ul>
+            </div>
+          </div>
+        </nav>
         <div class="admin-container">
             <!-- Espacio para los 3 logos -->
             <div class="logo-container">
@@ -25,24 +42,6 @@
                     <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
                 </div>
             </div>
-
-            <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-              <div class="container-fluid">
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-                        data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false"
-                        aria-label="Toggle navigation">
-                  <span class="navbar-toggler-icon"></span>
-                </button>
-                <div class="collapse navbar-collapse" id="adminNav">
-                  <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('administrar_factores') }}"><i class="bi bi-pencil-square me-1"></i>Editar Factores</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('administrar_formularios') }}"><i class="bi bi-ui-checks-grid me-1"></i>Administrar Formularios</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('vista_ranking') }}"><i class="bi bi-bar-chart-line me-1"></i>Ver Ranking Global</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_logout') }}"><i class="bi bi-box-arrow-right me-1"></i>Cerrar sesión</a></li>
-                  </ul>
-                </div>
-              </div>
-            </nav>
 
             <h2>Panel del Administrador</h2>
 


### PR DESCRIPTION
## Summary
- Place admin navigation bar outside the central admin container and apply dedicated styling
- Adjust admin container spacing and add `.admin-navbar` for margin control

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe64101b0832291ce1abf1b4857c9