### PR TITLE
Move login logos outside login cards

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -724,3 +724,25 @@ input[type="number"].ponderacion:focus {
 .btn-acento:hover .bi-arrow-repeat {
     transform: rotate(360deg);
 }
+
+.login-logos {
+    position: fixed;
+    bottom: 10px;
+    right: 10px;
+    display: flex;
+    gap: 0.5rem;
+}
+
+.login-logos img {
+    background: transparent;
+    border: none;
+    height: 60px;
+}
+
+@media (max-width: 576px) {
+    .login-logos {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+    }
+}

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -13,19 +13,6 @@
 <body>
     <div class="container py-5">
         <div class="login-admin-card mx-auto">
-            <!-- Logos -->
-            <div class="logo-container">
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                </div>
-                <div class="logo-img-container">
-                    <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                </div>
-            </div>
-
             <h2>Acceso Administrador</h2>
 
             {% with messages = get_flashed_messages() %}
@@ -63,6 +50,11 @@
     </script>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <div class="login-logos">
+        <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+        <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+        <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+    </div>
 </body>
 
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,19 +41,6 @@
             </div>
 
             <div class="card-body">
-                <!-- Espacio para los 3 logos -->
-                <div class="logo-container">
-                    <div class="logo-img-container">
-                        <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
-                    </div>
-                    <div class="logo-img-container">
-                        <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
-                    </div>
-                    <div class="logo-img-container">
-                        <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
-                    </div>
-                </div>
-
                 <form action="/formulario_redirect" method="post">
                     <div class="mb-3">
                         <label for="usuario_id" class="form-label">ID de Usuario</label>
@@ -110,6 +97,11 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <div class="login-logos">
+        <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+        <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+        <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove inline logo container from login and admin login pages
- show logos in fixed bottom-right bar instead
- style the new logo bar with responsive centering and transparent images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff51109d88322bbe87325034bd504