### PR TITLE
Add reusable login background and update admin login layout

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -725,6 +725,12 @@ input[type="number"].ponderacion:focus {
     transform: rotate(360deg);
 }
 
+.login-background {
+    background: url("../img/background.png") no-repeat center center fixed;
+    background-size: cover;
+    min-height: 100vh;
+}
+
 .login-logos {
     position: fixed;
     bottom: 10px;

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 
-<body>
+<body class="login-background">
     <div class="container py-5">
         <div class="login-admin-card mx-auto">
             <h2>Acceso Administrador</h2>


### PR DESCRIPTION
## Summary
- add `login-background` class for unified background image styling
- apply `login-background` to admin login page and ensure logo container uses `.login-logos`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ff6505e3c8322972c24757bbddb49