### PR TITLE
Optimize ranking query with CTE and indexes

### DIFF
--- a/app.py
+++ b/app.py
@@ -636,21 +636,21 @@ def vista_ranking():
         incompletas = [row["id_respuesta"] for row in incompletas_rows]
 
         ranking_query = """
+            WITH respuestas_completas AS (
+                SELECT id_respuesta
+                FROM ponderacion_admin
+                GROUP BY id_respuesta
+                HAVING COUNT(id_factor) = %s
+            )
             SELECT f.nombre,
-                   SUM(COALESCE(pa.peso_admin,0) * COALESCE(rd.valor_usuario,0)) AS total
+                   SUM(pa.peso_admin * rd.valor_usuario) AS total
             FROM factor f
-            LEFT JOIN ponderacion_admin pa ON f.id = pa.id_factor
-            LEFT JOIN (
-                SELECT r.id AS id_respuesta
-                FROM respuesta r
-                LEFT JOIN ponderacion_admin pa2 ON r.id = pa2.id_respuesta
-                GROUP BY r.id
-                HAVING COUNT(pa2.id_factor) < %s
-            ) p ON pa.id_respuesta = p.id_respuesta
-            LEFT JOIN respuesta_detalle rd
+            JOIN ponderacion_admin pa ON f.id = pa.id_factor
+            JOIN respuestas_completas rc ON pa.id_respuesta = rc.id_respuesta
+            JOIN respuesta_detalle rd
                 ON rd.id_respuesta = pa.id_respuesta AND rd.id_factor = f.id
-            WHERE p.id_respuesta IS NULL
-            GROUP BY f.id ORDER BY total DESC
+            GROUP BY f.id
+            ORDER BY total DESC
         """
         g.cursor.execute(ranking_query, (10,))
         ranking = g.cursor.fetchall()

--- a/database/modelo.sql
+++ b/database/modelo.sql
@@ -57,6 +57,10 @@ CREATE TABLE respuesta_detalle (
     UNIQUE (id_respuesta, id_factor)       -- impide duplicar factores
 );
 
+-- Índice para acelerar consultas por respuesta y factor
+CREATE INDEX idx_respuesta_detalle_respuesta_factor
+    ON respuesta_detalle (id_respuesta, id_factor);
+
 -- Tabla de ponderación del administrador sobre cada respuesta
 CREATE TABLE ponderacion_admin (
     id INT AUTO_INCREMENT PRIMARY KEY,
@@ -67,6 +71,10 @@ CREATE TABLE ponderacion_admin (
     FOREIGN KEY (id_factor) REFERENCES factor(id),
     UNIQUE (id_respuesta, id_factor)
 );
+
+-- Índice para búsquedas por respuesta en ponderaciones
+CREATE INDEX idx_ponderacion_admin_respuesta
+    ON ponderacion_admin (id_respuesta);
 
 -- Insertar los 54 formularios
 INSERT INTO formulario (nombre)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -82,7 +82,8 @@ def test_vista_ranking_parametrized(monkeypatch):
     ranking_query, ranking_params = cursor.queries[3]
     assert "HAVING COUNT(p.id_factor) < %s" in incompletas_query
     assert incompletas_params == (10,)
-    assert "HAVING COUNT(pa2.id_factor) < %s" in ranking_query
+    assert "WITH respuestas_completas" in ranking_query
+    assert "HAVING COUNT(id_factor) = %s" in ranking_query
     assert ranking_params == (10,)
 
 


### PR DESCRIPTION
## Summary
- Replaced ranking aggregation with a CTE that pre-filters fully weighted responses
- Added explicit indexes on ponderacion_admin.id_respuesta and respuesta_detalle(id_respuesta, id_factor)
- Updated tests for new query signature

## Testing
- `python -m pytest -q`
- `python - <<'PY'
import sqlite3
conn = sqlite3.connect(':memory:')
cur = conn.cursor()
cur.execute('CREATE TABLE ponderacion_admin (id_respuesta INT, id_factor INT, peso_admin FLOAT)')
cur.execute('CREATE INDEX idx_ponderacion_admin_respuesta ON ponderacion_admin (id_respuesta)')
cur.execute('CREATE TABLE respuesta_detalle (id_respuesta INT, id_factor INT, valor_usuario INT)')
cur.execute('CREATE INDEX idx_respuesta_detalle_respuesta_factor ON respuesta_detalle (id_respuesta, id_factor)')
cur.execute('CREATE TABLE factor (id INT, nombre TEXT)')
cur.executemany('INSERT INTO ponderacion_admin VALUES (?,?,?)', [(1,1,5.0),(1,2,4.0),(2,1,2.0)])
cur.executemany('INSERT INTO respuesta_detalle VALUES (?,?,?)', [(1,1,3),(1,2,2),(2,1,5)])
cur.executemany('INSERT INTO factor VALUES (?,?)', [(1,'Factor1'),(2,'Factor2')])
query = '''
WITH respuestas_completas AS (
    SELECT id_respuesta
    FROM ponderacion_admin
    GROUP BY id_respuesta
    HAVING COUNT(id_factor) = ?
)
SELECT f.nombre,
       SUM(pa.peso_admin * rd.valor_usuario) AS total
FROM factor f
JOIN ponderacion_admin pa ON f.id = pa.id_factor
JOIN respuestas_completas rc ON pa.id_respuesta = rc.id_respuesta
JOIN respuesta_detalle rd
    ON rd.id_respuesta = pa.id_respuesta AND rd.id_factor = f.id
GROUP BY f.id
ORDER BY total DESC
'''
print('EXPLAIN QUERY PLAN')
for row in cur.execute('EXPLAIN QUERY PLAN ' + query, (2,)):
    print(row)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689004c03aec8322b7747f2243d01ada