### PR TITLE
Use inline subquery for ranking query

### DIFF
--- a/app.py
+++ b/app.py
@@ -638,17 +638,16 @@ def vista_ranking():
         incompletas = [row["id_respuesta"] for row in incompletas_rows]
 
         ranking_query = """
-            WITH respuestas_completas AS (
-                SELECT id_respuesta
-                FROM ponderacion_admin
-                GROUP BY id_respuesta
-                HAVING COUNT(id_factor) = %s
-            )
             SELECT f.nombre,
                    SUM(pa.peso_admin * rd.valor_usuario) AS total
             FROM factor f
             JOIN ponderacion_admin pa ON f.id = pa.id_factor
-            JOIN respuestas_completas rc ON pa.id_respuesta = rc.id_respuesta
+            JOIN (
+                SELECT id_respuesta
+                FROM ponderacion_admin
+                GROUP BY id_respuesta
+                HAVING COUNT(id_factor) = %s
+            ) rc ON pa.id_respuesta = rc.id_respuesta
             JOIN respuesta_detalle rd
                 ON rd.id_respuesta = pa.id_respuesta AND rd.id_factor = f.id
             GROUP BY f.id

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -81,9 +81,35 @@ def test_vista_ranking_parametrized(monkeypatch):
     ranking_query, ranking_params = cursor.queries[3]
     assert "HAVING COUNT(p.id_factor) < %s" in incompletas_query
     assert incompletas_params == (10,)
-    assert "WITH respuestas_completas" in ranking_query
+    assert "JOIN (" in ranking_query
     assert "HAVING COUNT(id_factor) = %s" in ranking_query
     assert ranking_params == (10,)
+
+
+def test_vista_ranking_incompletas(monkeypatch):
+    cursor = DummyCursor(
+        fetchone_results=[
+            {"total": 1},  # total_asignados
+            {"total": 1},  # total_respuestas
+        ],
+        fetchall_results=[
+            [{"id_respuesta": 42}],  # incompletas_rows
+            [{"nombre": "Factor X", "total": 5}],  # ranking
+        ],
+    )
+    conn = DummyConnection(cursor)
+    monkeypatch.setattr(db, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+
+    cache.delete(RANKING_CACHE_KEY)
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["is_admin"] = True
+        resp = client.get("/admin/ranking")
+        assert resp.status_code == 200
+        assert b"Factor X" in resp.data
+        assert b"ID: 42" in resp.data
 
 
 def test_ranking_cache_invalidation_after_ponderacion(monkeypatch):


### PR DESCRIPTION
## Summary
- replace CTE in admin ranking query with inline subquery for wider MySQL compatibility
- extend tests to cover incomplete responses and new query structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68902de5fd888322aa4481b61d15a63b