### PR TITLE
Add shared background to all views

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -10,7 +10,8 @@
 }
 
 body {
-  background: linear-gradient(135deg, var(--color-claro-1), var(--color-claro-2));
+  background: url('../img/background.png') no-repeat center center fixed;
+  background-size: cover;
   min-height: 100vh;
   font-family: 'Poppins', sans-serif;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,11 +10,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <style>
-        body {
-            background: url("{{ url_for('static', filename='img/background.png') }}") no-repeat center center fixed;
-            background-size: cover;
-        }
-
         .login-card {
             background-color: white;
             /* Fondo blanco */


### PR DESCRIPTION
## Summary
- Apply a common background image via the global stylesheet so every view uses the same backdrop
- Clean up index page by removing inline body background and relying on shared styles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904bdc35188322888f48739a3dcd4d