### PR TITLE
Posiciona logos en esquina inferior derecha

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -48,14 +48,15 @@ h2::after {
   transform: translateY(-2px);
 }
 
-.logo-container {
+.logo-container,
+.login-logos {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
   display: flex;
-  justify-content: space-around;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-  padding: 0 1rem;
+  gap: 0.5rem;
 }
 
 /* Styles from templates/formulario.html */
@@ -741,14 +742,6 @@ input[type="number"].ponderacion:focus {
     min-height: 100vh;
 }
 
-.login-logos {
-    position: fixed;
-    bottom: 10px;
-    right: 10px;
-    display: flex;
-    gap: 0.5rem;
-}
-
 .login-logos img {
     background: transparent;
     border: none;
@@ -756,6 +749,7 @@ input[type="number"].ponderacion:focus {
 }
 
 @media (max-width: 576px) {
+    .logo-container,
     .login-logos {
         left: 50%;
         right: auto;


### PR DESCRIPTION
## Resumen
- Fija los contenedores de logos en la esquina inferior derecha.
- Ajusta la posición de los logos para dispositivos móviles.

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890592b91248322a2b08b05b7532430