### PR TITLE
Use dynamic factor count in ranking view

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,9 +58,10 @@ def get_factores():
 
 
 def invalidate_factores_cache():
-    """Reinicia el caché de factores."""
+    """Reinicia el caché de factores y del ranking relacionado."""
     FACTORES_CACHE["data"] = None
     FACTORES_CACHE["timestamp"] = 0
+    invalidate_ranking_cache()
 
 
 def get_db():
@@ -642,6 +643,9 @@ def vista_ranking():
         ranking = cached["ranking"]
         incompletas = cached["incompletas"]
     else:
+        # Número de factores a considerar en las consultas
+        count_factores = len(get_factores())
+
         # Detectar respuestas con ponderaciones incompletas
         incompletas_query = """
             SELECT r.id AS id_respuesta
@@ -650,7 +654,7 @@ def vista_ranking():
             GROUP BY r.id
             HAVING COUNT(p.id_factor) < %s
         """
-        g.cursor.execute(incompletas_query, (10,))
+        g.cursor.execute(incompletas_query, (count_factores,))
         incompletas_rows = g.cursor.fetchall()
         incompletas = [row["id_respuesta"] for row in incompletas_rows]
 
@@ -670,7 +674,7 @@ def vista_ranking():
             GROUP BY f.id, f.nombre
             ORDER BY total DESC
         """
-        g.cursor.execute(ranking_query, (10,))
+        g.cursor.execute(ranking_query, (count_factores,))
         ranking = g.cursor.fetchall()
 
         cache.set(

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -64,6 +64,9 @@ def test_vista_ranking_parametrized(monkeypatch):
     conn = DummyConnection(cursor)
     monkeypatch.setattr(db, "get_connection", lambda: conn)
     monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+    # mock factores count to ensure dynamic parameter is used
+    expected_count = 7
+    monkeypatch.setattr(app_module, "get_factores", lambda: [object()] * expected_count)
 
     # reset cache
     cache.delete(RANKING_CACHE_KEY)
@@ -80,10 +83,10 @@ def test_vista_ranking_parametrized(monkeypatch):
     incompletas_query, incompletas_params = cursor.queries[2]
     ranking_query, ranking_params = cursor.queries[3]
     assert "HAVING COUNT(p.id_factor) < %s" in incompletas_query
-    assert incompletas_params == (10,)
+    assert incompletas_params == (expected_count,)
     assert "JOIN (" in ranking_query
     assert "HAVING COUNT(id_factor) = %s" in ranking_query
-    assert ranking_params == (10,)
+    assert ranking_params == (expected_count,)
 
 
 def test_vista_ranking_incompletas(monkeypatch):
@@ -100,6 +103,7 @@ def test_vista_ranking_incompletas(monkeypatch):
     conn = DummyConnection(cursor)
     monkeypatch.setattr(db, "get_connection", lambda: conn)
     monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_factores", lambda: [object()] * 5)
 
     cache.delete(RANKING_CACHE_KEY)
 
@@ -126,6 +130,7 @@ def test_ranking_cache_invalidation_after_ponderacion(monkeypatch):
     conn = DummyConnection(cursor)
     monkeypatch.setattr(db, "get_connection", lambda: conn)
     monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_factores", lambda: [object()] * 4)
 
     cache.delete(RANKING_CACHE_KEY)
 


### PR DESCRIPTION
## Summary
- derive factor count dynamically in `vista_ranking` and use it as SQL parameter
- clear ranking cache when factor cache is invalidated
- adjust ranking tests to mock factor count

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68918ee93ee883228d95922880baa8f6