### PR TITLE
Allow flexible valor_usuario range

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,23 @@ WHERE n <= 54;
 
 Ejecuta ese fragmento en la base de datos `sistema_formularios` para disponer de los formularios desde el inicio.
 
+## Actualización de esquema
+
+La columna `respuesta_detalle.valor_usuario` ahora valida únicamente que el valor sea mayor o igual a 1, eliminando el límite superior de 10 para permitir cualquier número de factores.
+
+Para actualizar una instalación existente, ejecuta el siguiente comando (ajusta el nombre del `CHECK` original según tu instancia, puedes consultarlo con `SHOW CREATE TABLE respuesta_detalle;`):
+
+```sql
+ALTER TABLE respuesta_detalle
+  DROP CHECK respuesta_detalle_chk_1,
+  ADD CONSTRAINT chk_valor_usuario CHECK (valor_usuario >= 1);
+```
+
+Si deseas mantener un rango acotado, reemplaza la última línea por:
+
+```sql
+  ADD CONSTRAINT chk_valor_usuario CHECK (valor_usuario BETWEEN 1 AND <numero_maximo_de_factores>);
+```
+
+Sustituye `<numero_maximo_de_factores>` por la cantidad máxima de factores que esperas manejar.
+

--- a/database/modelo.sql
+++ b/database/modelo.sql
@@ -45,12 +45,13 @@ CREATE TABLE respuesta (
     UNIQUE (id_usuario, id_formulario)
 );
 
--- Detalle de las respuestas por factor (valor de 1 a 10, sin repetir por respuesta)
+-- Detalle de las respuestas por factor (valor >= 1, sin repetir por respuesta)
 CREATE TABLE respuesta_detalle (
     id INT AUTO_INCREMENT PRIMARY KEY,
     id_respuesta INT NOT NULL,
     id_factor INT NOT NULL,
-    valor_usuario INT NOT NULL CHECK (valor_usuario BETWEEN 1 AND 10),
+    valor_usuario INT NOT NULL,
+    CONSTRAINT chk_valor_usuario CHECK (valor_usuario >= 1),
     FOREIGN KEY (id_respuesta) REFERENCES respuesta(id) ON DELETE CASCADE,
     FOREIGN KEY (id_factor) REFERENCES factor(id),
     UNIQUE (id_respuesta, valor_usuario),  -- impide duplicar valores


### PR DESCRIPTION
## Summary
- Allow `respuesta_detalle.valor_usuario` to accept any value >=1 by removing the upper bound and naming the check constraint.
- Document schema update with migration instructions and optional upper bound.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689190dc17b083229e602cce3b729a97