### PR TITLE
Add color badges for factors

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -9,6 +9,22 @@
   --color-claro-2: #90c6ff;
 }
 
+/* Reusable color indicators */
+.color-badge {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.25rem;
+}
+
+.color-label {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.25rem;
+  color: #fff;
+  font-size: 0.875rem;
+}
+
 body {
   background: url('../img/background.png') no-repeat center center fixed;
   background-size: cover;

--- a/templates/admin_detalle.html
+++ b/templates/admin_detalle.html
@@ -48,7 +48,9 @@
                         <tbody>
                             {% for f in factores %}
                             <tr>
-                                <td class="factor-name">{{ f.nombre }}</td>
+                                <td class="factor-name">
+                                    <span class="color-label" style="background-color: {{ f.color or '#cccccc' }};">{{ f.nombre }}</span>
+                                </td>
                                 <td class="factor-desc text-start">{{ f.descripcion }}</td>
                                 <td>{{ f.valor_usuario }}</td>
                                 <td>

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -64,7 +64,7 @@
             {% for r in ranking %}
             <tr>
               <td>{{ loop.index }}</td>
-              <td>{{ r.nombre }}</td>
+              <td><span class="color-badge me-1" style="background-color: {{ r.color or '#cccccc' }};"></span>{{ r.nombre }}</td>
               <td>
                 {{ '%.2f' | format(r.total or 0) }}
                 {% if (r.total or 0) == 0 %}
@@ -97,6 +97,7 @@
     // Renderizar gráfico con datos desde Jinja
     const factorLabels = {{ ranking | map(attribute='nombre') | list | tojson | safe }};
     const factorTotals = {{ ranking | map(attribute='total') | list | tojson | safe }};
+    const factorColors = {{ ranking | map(attribute='color') | map('default', '#cccccc') | list | tojson | safe }};
 
     const ctx = document.getElementById('rankingChart').getContext('2d');
     new Chart(ctx, {
@@ -106,8 +107,8 @@
         datasets: [{
           label: 'Total Ponderado',
           data: factorTotals,
-          backgroundColor: 'rgba(32, 133, 140, 0.5)',
-          borderColor: 'rgba(32, 133, 140, 1)',
+          backgroundColor: factorColors,
+          borderColor: factorColors,
           borderWidth: 1
         }]
       },

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -111,6 +111,7 @@
                             <tr>
                                 <td>
                                     <strong>{{ factor.nombre }}</strong>
+                                    <span class="color-badge ms-2" style="background-color: {{ factor.color or '#cccccc' }};"></span>
                                     <input type="hidden" name="factor_id_{{ loop.index }}" value="{{ factor.id }}">
                                 </td>
                                 <td>{{ factor.descripcion }}</td>


### PR DESCRIPTION
## Summary
- display factor-specific color badges in form and admin views
- use factor color palette in ranking table and bar chart
- add reusable CSS classes for color badges and labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689198c4a1888322ad33e4db3d082a96