### PR TITLE
Style color labels in evaluation form

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -19,10 +19,12 @@
 
 .color-label {
   display: inline-block;
-  padding: 0.2rem 0.5rem;
+  padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
   color: #fff;
   font-size: 0.875rem;
+  font-weight: 500;
+  vertical-align: middle;
 }
 
 body {

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -110,8 +110,7 @@
                             {% for factor in factores %}
                             <tr>
                                 <td>
-                                    <strong>{{ factor.nombre }}</strong>
-                                    <span class="color-badge ms-2" style="background-color: {{ factor.color or '#cccccc' }};"></span>
+                                    <span class="color-label" style="background-color: {{ factor.color or '#cccccc' }};">{{ factor.nombre }}</span>
                                     <input type="hidden" name="factor_id_{{ loop.index }}" value="{{ factor.id }}">
                                 </td>
                                 <td>{{ factor.descripcion }}</td>


### PR DESCRIPTION
## Summary
- refine color label CSS for better readability
- show factor name inside a colored label in the evaluation form

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891960932e88322bfdc452043a72e4b