### PR TITLE
Display factor colors as left-edge strips

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -17,13 +17,6 @@
   border-radius: 0.25rem;
 }
 
-.color-label {
-  display: inline-block;
-  padding: 0.2rem 0.5rem;
-  border-radius: 0.25rem;
-  color: #fff;
-  font-size: 0.875rem;
-}
 
 body {
   background: url('../img/background.png') no-repeat center center fixed;
@@ -663,6 +656,18 @@ input[type="number"].ponderacion:focus {
 .factor-name {
   color: var(--color-primario-medio);
   font-weight: 500;
+  position: relative;
+  padding-left: 1rem;
+}
+
+.factor-name::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0.5rem;
+  background-color: var(--color, #cccccc);
 }
 
 .factor-desc {

--- a/templates/admin_detalle.html
+++ b/templates/admin_detalle.html
@@ -48,8 +48,8 @@
                         <tbody>
                             {% for f in factores %}
                             <tr>
-                                <td class="factor-name">
-                                    <span class="color-label" style="background-color: {{ f.color or '#cccccc' }};">{{ f.nombre }}</span>
+                                <td class="factor-name" style="--color: {{ f.color or '#cccccc' }};">
+                                    {{ f.nombre }}
                                 </td>
                                 <td class="factor-desc text-start">{{ f.descripcion }}</td>
                                 <td>{{ f.valor_usuario }}</td>

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -109,9 +109,8 @@
                         <tbody>
                             {% for factor in factores %}
                             <tr>
-                                <td>
-                                    <strong>{{ factor.nombre }}</strong>
-                                    <span class="color-badge ms-2" style="background-color: {{ factor.color or '#cccccc' }};"></span>
+                                <td class="factor-name" style="--color: {{ factor.color or '#cccccc' }};">
+                                    {{ factor.nombre }}
                                     <input type="hidden" name="factor_id_{{ loop.index }}" value="{{ factor.id }}">
                                 </td>
                                 <td>{{ factor.descripcion }}</td>


### PR DESCRIPTION
## Summary
- convert factor color indicators into vertical strips along the left edge of factor cells
- apply the new strip style to both the evaluation form and the admin weighting view

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891960932e88322bfdc452043a72e4b