### PR TITLE
Implement lock state caching for forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,34 @@ FACTORES_CACHE = {"data": None, "timestamp": 0}
 FACTORES_CACHE_TTL = int(os.getenv("FACTORES_CACHE_TTL", 300))
 
 
+# Cache ligero para estado de bloqueo por (id_usuario, id_formulario)
+BLOQUEO_CACHE = {}
+BLOQUEO_CACHE_TTL = int(os.getenv("BLOQUEO_CACHE_TTL", 60))
+
+
+def is_formulario_bloqueado(id_usuario: int, id_formulario: int) -> bool:
+    """Devuelve True si el formulario está bloqueado para el usuario."""
+    key = (id_usuario, id_formulario)
+    now = time.time()
+    entry = BLOQUEO_CACHE.get(key)
+    if entry and now - entry["timestamp"] <= BLOQUEO_CACHE_TTL:
+        return entry["bloqueado"]
+
+    get_db()
+    g.cursor.execute(
+        "SELECT 1 FROM respuesta WHERE id_usuario = %s AND id_formulario = %s AND bloqueado = 1",
+        (id_usuario, id_formulario),
+    )
+    bloqueado = g.cursor.fetchone() is not None
+    BLOQUEO_CACHE[key] = {"bloqueado": bloqueado, "timestamp": now}
+    return bloqueado
+
+
+def invalidate_bloqueo_cache(id_usuario: int, id_formulario: int):
+    """Elimina la entrada de caché para un usuario y formulario."""
+    BLOQUEO_CACHE.pop((id_usuario, id_formulario), None)
+
+
 def get_factores():
     """Obtiene la lista de factores usando caché en memoria."""
     now = time.time()
@@ -145,12 +173,8 @@ def mostrar_formulario(id_usuario):
 
     id_formulario = asignacion["id_formulario"]
 
-    # Verificar si el formulario ya fue respondido y está bloqueado
-    g.cursor.execute(
-        "SELECT 1 FROM respuesta WHERE id_usuario = %s AND id_formulario = %s AND bloqueado = 1",
-        (id_usuario, id_formulario),
-    )
-    if g.cursor.fetchone():
+    # Verificar si el formulario ya fue respondido y está bloqueado (usa caché)
+    if is_formulario_bloqueado(id_usuario, id_formulario):
         return render_template("formulario_bloqueado.html")
 
     # Obtener factores (con caché)
@@ -199,6 +223,10 @@ def guardar_respuesta():
     id_usuario = int(request.form["usuario_id"])
     id_formulario = int(request.form["formulario_id"])
     exit_redirect = request.form.get("exit_redirect")
+
+    # Verificar bloqueo mediante caché antes de acceder a la base de datos
+    if is_formulario_bloqueado(id_usuario, id_formulario):
+        return render_template("formulario_bloqueado.html")
 
     get_db()
     num_factores = len(get_factores())
@@ -303,6 +331,8 @@ def guardar_respuesta():
         flash("Error al guardar la respuesta. Intenta nuevamente.")
         return redirect(url_for("mostrar_formulario", id_usuario=id_usuario))
 
+    # Limpiar cachés dependientes
+    invalidate_bloqueo_cache(id_usuario, id_formulario)
     invalidate_ranking_cache()
     if exit_redirect:
         return redirect(url_for("index"))
@@ -487,10 +517,17 @@ def abrir_respuesta(id_respuesta):
 
     get_db()
     g.cursor.execute(
+        "SELECT id_usuario, id_formulario FROM respuesta WHERE id = %s",
+        (id_respuesta,),
+    )
+    datos = g.cursor.fetchone()
+    g.cursor.execute(
         "UPDATE respuesta SET bloqueado = 0 WHERE id = %s",
         (id_respuesta,),
     )
     g.conn.commit()
+    if datos:
+        invalidate_bloqueo_cache(datos["id_usuario"], datos["id_formulario"])
     invalidate_ranking_cache()
     flash("Respuesta reabierta correctamente.")
     return redirect(url_for("panel_admin"))

--- a/tests/test_admin_formularios.py
+++ b/tests/test_admin_formularios.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -10,6 +11,7 @@ import app as app_module
 app = app_module.app
 cache = app_module.cache
 RANKING_CACHE_KEY = app_module.RANKING_CACHE_KEY
+BLOQUEO_CACHE = app_module.BLOQUEO_CACHE
 
 class DummyCursor:
     def __init__(self, fetchone_results=None):
@@ -110,8 +112,11 @@ def test_abrir_formulario_requires_admin(monkeypatch):
 
 
 def test_abrir_formulario(monkeypatch):
-    cursor, conn = create_dummy(monkeypatch)
+    fetchone_results = [{"id_usuario": 2, "id_formulario": 7}]
+    cursor, conn = create_dummy(monkeypatch, fetchone_results=fetchone_results)
     cache.set(RANKING_CACHE_KEY, {"ranking": "x"})
+    BLOQUEO_CACHE.clear()
+    BLOQUEO_CACHE[(2, 7)] = {"bloqueado": True, "timestamp": time.time()}
 
     with app.test_client() as client:
         with client.session_transaction() as sess:
@@ -121,7 +126,9 @@ def test_abrir_formulario(monkeypatch):
         assert resp.headers["Location"].endswith("/admin")
 
     assert cursor.queries == [
+        ("SELECT id_usuario, id_formulario FROM respuesta WHERE id = %s", (5,)),
         ("UPDATE respuesta SET bloqueado = 0 WHERE id = %s", (5,)),
     ]
     assert conn.commit_called
     assert cache.get(RANKING_CACHE_KEY) is None
+    assert (2, 7) not in BLOQUEO_CACHE

--- a/tests/test_guardar_respuesta.py
+++ b/tests/test_guardar_respuesta.py
@@ -1,0 +1,111 @@
+import os
+import sys
+import time
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import db
+import app as app_module
+
+app = app_module.app
+BLOQUEO_CACHE = app_module.BLOQUEO_CACHE
+
+class DummyCursor:
+    def __init__(self, fetchone_results=None):
+        self.queries = []
+        self.fetchone_results = fetchone_results or []
+        self.lastrowid = 10
+
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+
+    def executemany(self, query, seq_params):
+        self.queries.append((query, seq_params))
+
+    def fetchone(self):
+        return self.fetchone_results.pop(0) if self.fetchone_results else None
+
+    def close(self):
+        pass
+
+class DummyConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.start_transaction_called = False
+        self.commit_called = False
+
+    def cursor(self, dictionary=True):
+        return self._cursor
+
+    def start_transaction(self):
+        self.start_transaction_called = True
+
+    def commit(self):
+        self.commit_called = True
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+def create_dummy(monkeypatch, fetchone_results=None):
+    cursor = DummyCursor(fetchone_results=fetchone_results)
+    conn = DummyConnection(cursor)
+    monkeypatch.setattr(db, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+    return cursor, conn
+
+def test_guardar_respuesta_cache_bloqueado_evita_db(monkeypatch):
+    called = {"value": False}
+
+    def fake_get_connection():
+        called["value"] = True
+        cursor = DummyCursor()
+        return DummyConnection(cursor)
+
+    monkeypatch.setattr(db, "get_connection", fake_get_connection)
+    monkeypatch.setattr(app_module, "get_connection", fake_get_connection)
+
+    BLOQUEO_CACHE.clear()
+    BLOQUEO_CACHE[(1, 2)] = {"bloqueado": True, "timestamp": time.time()}
+
+    with app.test_client() as client:
+        resp = client.post("/guardar_respuesta", data={"usuario_id": "1", "formulario_id": "2"})
+        assert resp.status_code == 200
+        assert b"El formulario ya se respondi" in resp.data
+
+    assert not called["value"]
+
+
+def test_guardar_respuesta_invalida_cache(monkeypatch):
+    cursor, conn = create_dummy(monkeypatch, fetchone_results=[None])
+    monkeypatch.setattr(app_module, "get_factores", lambda: [{"id": 1}])
+
+    BLOQUEO_CACHE.clear()
+    BLOQUEO_CACHE[(1, 2)] = {"bloqueado": False, "timestamp": time.time()}
+
+    data = {
+        "usuario_id": "1",
+        "formulario_id": "2",
+        "nombre": "N",
+        "apellidos": "A",
+        "cargo": "C",
+        "dependencia": "D",
+        "factor_id_1": "1",
+        "valor_1": "1",
+    }
+
+    with app.test_client() as client:
+        resp = client.post("/guardar_respuesta", data=data)
+        assert resp.status_code == 200
+
+    assert len(cursor.queries) == 4
+    assert "UPDATE usuario" in cursor.queries[0][0]
+    assert "SELECT id FROM respuesta" in cursor.queries[1][0]
+    assert "INSERT INTO respuesta" in cursor.queries[2][0]
+    assert "INSERT INTO respuesta_detalle" in cursor.queries[3][0]
+    assert conn.start_transaction_called
+    assert conn.commit_called
+    assert (1, 2) not in BLOQUEO_CACHE


### PR DESCRIPTION
## Summary
- add in-memory cache with TTL to store form lock state per user
- consult cache in form display and submission, invalidating on updates or admin reopen
- add unit tests for cache behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891a8eaf2348322bf08ee4b3e8888dd