### PR TITLE
Ensure bloqueo cache can be configured and invalidated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Configura las siguientes variables de entorno antes de ejecutar la aplicación:
 - `DB_USER`: usuario de la base de datos.
 - `DB_PASSWORD`: contraseña del usuario.
 - `DB_NAME`: nombre de la base de datos.
+- `BLOQUEO_CACHE_TTL`: (opcional) segundos que permanece en caché el estado de bloqueo de un formulario. Valor por defecto: 30.
 
 Ejemplo en Linux/Mac:
 
@@ -71,4 +72,12 @@ Si deseas mantener un rango acotado, reemplaza la última línea por:
 ```
 
 Sustituye `<numero_maximo_de_factores>` por la cantidad máxima de factores que esperas manejar.
+
+## Caché de bloqueos
+
+El estado de bloqueo de cada formulario se almacena en memoria durante un
+tiempo determinado por `BLOQUEO_CACHE_TTL`. Cualquier acción administrativa
+que altere el campo `bloqueado` debe llamar a `invalidate_bloqueo_cache` con
+el identificador del usuario y del formulario para eliminar la entrada
+correspondiente y evitar inconsistencias visibles.
 

--- a/app.py
+++ b/app.py
@@ -46,7 +46,7 @@ FACTORES_CACHE_TTL = int(os.getenv("FACTORES_CACHE_TTL", 300))
 
 # Cache ligero para estado de bloqueo por (id_usuario, id_formulario)
 BLOQUEO_CACHE = {}
-BLOQUEO_CACHE_TTL = int(os.getenv("BLOQUEO_CACHE_TTL", 60))
+BLOQUEO_CACHE_TTL = int(os.getenv("BLOQUEO_CACHE_TTL", 30))
 
 
 def is_formulario_bloqueado(id_usuario: int, id_formulario: int) -> bool:
@@ -68,7 +68,12 @@ def is_formulario_bloqueado(id_usuario: int, id_formulario: int) -> bool:
 
 
 def invalidate_bloqueo_cache(id_usuario: int, id_formulario: int):
-    """Elimina la entrada de caché para un usuario y formulario."""
+    """Elimina la entrada de caché para un usuario y formulario.
+
+    Esta función debe llamarse tras cualquier operación que modifique el
+    campo ``bloqueado`` para evitar inconsistencias visibles entre el estado
+    real y el estado almacenado en caché.
+    """
     BLOQUEO_CACHE.pop((id_usuario, id_formulario), None)
 
 
@@ -486,6 +491,9 @@ def eliminar_formulario(id):
         g.cursor.execute("DELETE FROM asignacion WHERE id_formulario = %s", (id,))
         g.cursor.execute("DELETE FROM formulario WHERE id = %s", (id,))
         g.conn.commit()
+        for (uid, fid) in list(BLOQUEO_CACHE.keys()):
+            if fid == id:
+                invalidate_bloqueo_cache(uid, fid)
         invalidate_ranking_cache()
         flash("Formulario eliminado correctamente.")
         return redirect(url_for("administrar_formularios"))
@@ -505,6 +513,8 @@ def reiniciar_formularios():
     g.cursor.execute("DELETE FROM respuesta_detalle")
     g.cursor.execute("DELETE FROM respuesta")
     g.conn.commit()
+    for key in list(BLOQUEO_CACHE.keys()):
+        invalidate_bloqueo_cache(*key)
     invalidate_ranking_cache()
     flash("Todos los formularios han sido reiniciados.")
     return redirect(url_for("administrar_formularios"))

--- a/tests/test_admin_formularios.py
+++ b/tests/test_admin_formularios.py
@@ -59,6 +59,8 @@ def test_reiniciar_formularios_requires_admin(monkeypatch):
 def test_reiniciar_formularios(monkeypatch):
     cursor, conn = create_dummy(monkeypatch)
     cache.set(RANKING_CACHE_KEY, {"ranking": "x", "incompletas": "y"})
+    BLOQUEO_CACHE.clear()
+    BLOQUEO_CACHE[(5, 9)] = {"bloqueado": True, "timestamp": time.time()}
 
     with app.test_client() as client:
         with client.session_transaction() as sess:
@@ -74,6 +76,7 @@ def test_reiniciar_formularios(monkeypatch):
     ]
     assert conn.commit_called
     assert cache.get(RANKING_CACHE_KEY) is None
+    assert BLOQUEO_CACHE == {}
 
 
 def test_eliminar_formulario_invalida_cache(monkeypatch):
@@ -81,6 +84,8 @@ def test_eliminar_formulario_invalida_cache(monkeypatch):
     cursor, conn = create_dummy(monkeypatch, fetchone_results=fetchone_results)
 
     cache.set(RANKING_CACHE_KEY, {"ranking": "cached", "incompletas": "cached"})
+    BLOQUEO_CACHE.clear()
+    BLOQUEO_CACHE[(2, 1)] = {"bloqueado": True, "timestamp": time.time()}
 
     with app.test_client() as client:
         with client.session_transaction() as sess:
@@ -100,6 +105,7 @@ def test_eliminar_formulario_invalida_cache(monkeypatch):
     ]
     assert conn.commit_called
     assert cache.get(RANKING_CACHE_KEY) is None
+    assert (2, 1) not in BLOQUEO_CACHE
 
 
 def test_abrir_formulario_requires_admin(monkeypatch):


### PR DESCRIPTION
## Summary
- Reduce default `BLOQUEO_CACHE_TTL` to 30 seconds and document cache invalidation needs
- Clear bloqueo cache after admin actions that remove or reset responses
- Document `BLOQUEO_CACHE_TTL` environment variable and cache invalidation in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920770674c8322b720b993d6929dba