### PR TITLE
Valida id_respuesta antes de ponderar

### DIFF
--- a/app.py
+++ b/app.py
@@ -655,12 +655,15 @@ def detalle_respuesta(id_respuesta):
 def guardar_ponderacion():
     if not session.get("is_admin"):
         return redirect(url_for("admin_login"))
-    id_respuesta_raw = request.form.get("id_respuesta", "")
+    id_respuesta_raw = request.form.get("id_respuesta")
+    if not id_respuesta_raw:
+        flash("Falta el identificador de la respuesta.")
+        return redirect(url_for("panel_admin"))
     try:
         id_respuesta = int(id_respuesta_raw)
     except ValueError:
         flash("El identificador de la respuesta debe ser un número entero.")
-        return redirect(url_for("detalle_respuesta", id_respuesta=0))
+        return redirect(url_for("panel_admin"))
 
     get_db()
 

--- a/tests/test_guardar_ponderacion.py
+++ b/tests/test_guardar_ponderacion.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+
+app = app_module.app
+
+
+def _get_flashes(client):
+    with client.session_transaction() as sess:
+        return sess.get('_flashes', [])
+
+
+def test_guardar_ponderacion_sin_id_respuesta():
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['is_admin'] = True
+        resp = client.post('/admin/ponderar', data={'ponderacion_1': '5'})
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/admin')
+        flashes = _get_flashes(client)
+        assert any('Falta el identificador de la respuesta.' in msg for _, msg in flashes)
+
+
+def test_guardar_ponderacion_id_no_numerico():
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['is_admin'] = True
+        resp = client.post('/admin/ponderar', data={'id_respuesta': 'abc', 'ponderacion_1': '5'})
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/admin')
+        flashes = _get_flashes(client)
+        assert any('El identificador de la respuesta debe ser un número entero.' in msg for _, msg in flashes)


### PR DESCRIPTION
## Summary
- Verifica que `id_respuesta` exista y sea numérico antes de convertirlo en la ruta de ponderación, redirigiendo al panel con un mensaje claro cuando no lo es.
- Añade pruebas que cubren los casos de `id_respuesta` ausente y no numérico.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68920b69aed88322b6bf7ba64e9484e3