### PR TITLE
Handle missing auto-increment when suggesting form name

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,7 +416,8 @@ def administrar_formularios():
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'formulario'
         """
     )
-    siguiente_id = g.cursor.fetchone()["siguiente_id"]
+    row = g.cursor.fetchone()
+    siguiente_id = int(row["siguiente_id"] or 1)
     default_name = f"Formulario {siguiente_id:02d}"
 
     if request.method == "POST":

--- a/tests/test_admin_formularios.py
+++ b/tests/test_admin_formularios.py
@@ -47,6 +47,26 @@ def create_dummy(monkeypatch, fetchone_results=None):
     return cursor, conn
 
 
+def test_crear_formulario_nombre_por_defecto(monkeypatch):
+    fetchone_results = [{"siguiente_id": None}]
+    cursor, conn = create_dummy(monkeypatch, fetchone_results=fetchone_results)
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["is_admin"] = True
+        resp = client.post("/admin/formularios", data={"nombre": ""})
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/admin/formularios")
+
+    assert len(cursor.queries) == 2
+    assert "AUTO_INCREMENT AS siguiente_id" in cursor.queries[0][0]
+    assert cursor.queries[1] == (
+        "INSERT INTO formulario (nombre) VALUES (%s)",
+        ("Formulario 01",),
+    )
+    assert conn.commit_called
+
+
 def test_reiniciar_formularios_requires_admin(monkeypatch):
     cursor, conn = create_dummy(monkeypatch)
     with app.test_client() as client:


### PR DESCRIPTION
## Summary
- Convert `siguiente_id` to `int` and provide fallback when suggesting default form name
- Add regression test ensuring forms can be created without a provided name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689242028904832283285138abb796a4