### PR TITLE
Ignorar ponderación global en guardar_ponderacion

### DIFF
--- a/app.py
+++ b/app.py
@@ -673,6 +673,8 @@ def guardar_ponderacion():
     for key, value in request.form.items():
         if not key.startswith("ponderacion_"):
             continue
+        if key == "ponderacion_global":
+            continue
         valor = value.strip()
         if valor == "":
             continue

--- a/tests/test_guardar_ponderacion.py
+++ b/tests/test_guardar_ponderacion.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+import db
 import app as app_module
 
 app = app_module.app
@@ -33,3 +34,83 @@ def test_guardar_ponderacion_id_no_numerico():
         assert resp.headers['Location'].endswith('/admin')
         flashes = _get_flashes(client)
         assert any('El identificador de la respuesta debe ser un número entero.' in msg for _, msg in flashes)
+
+
+class DummyCursor:
+    def __init__(self, fetchone_results=None, fetchall_results=None):
+        self.queries = []
+        self.fetchone_results = fetchone_results or []
+        self.fetchall_results = fetchall_results or []
+
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+
+    def executemany(self, query, seq_params):
+        self.queries.append((query, seq_params))
+
+    def fetchone(self):
+        return self.fetchone_results.pop(0) if self.fetchone_results else None
+
+    def fetchall(self):
+        return self.fetchall_results.pop(0) if self.fetchall_results else []
+
+    def close(self):
+        pass
+
+
+class DummyConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.commit_called = 0
+
+    def cursor(self, dictionary=True):
+        return self._cursor
+
+    def commit(self):
+        self.commit_called += 1
+
+    def close(self):
+        pass
+
+
+def create_dummy(monkeypatch, fetchone_results=None, fetchall_results=None):
+    cursor = DummyCursor(fetchone_results=fetchone_results, fetchall_results=fetchall_results)
+    conn = DummyConnection(cursor)
+    monkeypatch.setattr(db, 'get_connection', lambda: conn)
+    monkeypatch.setattr(app_module, 'get_connection', lambda: conn)
+    return cursor, conn
+
+
+def test_guardar_ponderacion_ignora_global(monkeypatch):
+    factors = [
+        {
+            'id_factor': 2,
+            'nombre': 'F2',
+            'descripcion': 'D',
+            'valor_usuario': 3,
+            'peso_admin': 8.0,
+        }
+    ]
+    fetchone = [{'id_respuesta': 1, 'nombre': 'N', 'apellidos': 'A', 'formulario': 'Form'}]
+    cursor, conn = create_dummy(
+        monkeypatch,
+        fetchone_results=fetchone,
+        fetchall_results=[factors, []],
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['is_admin'] = True
+        data = {
+            'id_respuesta': '1',
+            'ponderacion_global': '7',
+            'ponderacion_2': '8',
+        }
+        resp = client.post('/admin/ponderar', data=data)
+        assert resp.status_code == 302
+        assert cursor.queries[0][1] == [(1, 2, 8.0)]
+        assert conn.commit_called == 1
+
+        resp2 = client.get('/admin/respuesta/1')
+        assert resp2.status_code == 200
+        assert b'value="8.0"' in resp2.data


### PR DESCRIPTION
## Summary
- Evitar que la clave `ponderacion_global` se interprete como un factor al guardar ponderaciones.
- Agregar prueba que simula el uso de "Aplicar a todos" y verifica el guardado y la visualización posterior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68924c618e6c8322b45936e23af0350d