### PR TITLE
Ensure ponderacion covers all factors

### DIFF
--- a/app.py
+++ b/app.py
@@ -669,40 +669,36 @@ def guardar_ponderacion():
 
     get_db()
 
+    factores = get_factores()
     ponderaciones = []
 
-    for key, value in request.form.items():
-        if not key.startswith("ponderacion_"):
-            continue
-        if key == "ponderacion_global":
-            continue
-        valor = value.strip()
-        if valor == "":
-            continue
-        try:
-            peso = Decimal(valor)
-        except InvalidOperation:
-            flash("Las ponderaciones deben ser valores numéricos.")
-            return redirect(url_for("detalle_respuesta", id_respuesta=id_respuesta))
+    for factor in factores:
+        id_factor = factor["id"]
+        valor = request.form.get(f"ponderacion_{id_factor}", "").strip()
+        if valor:
+            try:
+                peso = Decimal(valor)
+            except InvalidOperation:
+                flash("Las ponderaciones deben ser valores numéricos.")
+                return redirect(url_for("detalle_respuesta", id_respuesta=id_respuesta))
 
-        if peso < 0 or peso > 10:
-            flash("Cada ponderación debe estar entre 0 y 10.")
-            return redirect(url_for("detalle_respuesta", id_respuesta=id_respuesta))
+            if peso < 0 or peso > 10:
+                flash("Cada ponderación debe estar entre 0 y 10.")
+                return redirect(url_for("detalle_respuesta", id_respuesta=id_respuesta))
 
-        peso = peso.quantize(Decimal("0.1"))
-        try:
-            id_factor = int(key.split("_")[1])
-        except ValueError:
-            flash("El identificador del factor debe ser un número entero.")
-            return redirect(url_for("detalle_respuesta", id_respuesta=id_respuesta))
-        ponderaciones.append((id_respuesta, id_factor, float(peso)))
+            peso = float(peso.quantize(Decimal("0.1")))
+        else:
+            peso = 0.0
+        ponderaciones.append((id_respuesta, id_factor, peso))
 
+    g.cursor.execute(
+        "DELETE FROM ponderacion_admin WHERE id_respuesta = %s", (id_respuesta,)
+    )
     if ponderaciones:
         g.cursor.executemany(
             """
                 INSERT INTO ponderacion_admin (id_respuesta, id_factor, peso_admin)
                 VALUES (%s, %s, %s)
-                ON DUPLICATE KEY UPDATE peso_admin = VALUES(peso_admin)
             """,
             ponderaciones,
         )

--- a/tests/test_guardar_ponderacion.py
+++ b/tests/test_guardar_ponderacion.py
@@ -82,7 +82,8 @@ def create_dummy(monkeypatch, fetchone_results=None, fetchall_results=None):
 
 
 def test_guardar_ponderacion_ignora_global(monkeypatch):
-    factors = [
+    all_factors = [{'id': 1}, {'id': 2}]
+    detalle_factors = [
         {
             'id_factor': 2,
             'nombre': 'F2',
@@ -95,7 +96,7 @@ def test_guardar_ponderacion_ignora_global(monkeypatch):
     cursor, conn = create_dummy(
         monkeypatch,
         fetchone_results=fetchone,
-        fetchall_results=[factors, []],
+        fetchall_results=[all_factors, detalle_factors, []],
     )
 
     with app.test_client() as client:
@@ -108,7 +109,12 @@ def test_guardar_ponderacion_ignora_global(monkeypatch):
         }
         resp = client.post('/admin/ponderar', data=data)
         assert resp.status_code == 302
-        assert cursor.queries[0][1] == [(1, 2, 8.0)]
+        # First query selects factors, second deletes previous rows
+        delete_q, delete_params = cursor.queries[1]
+        assert 'DELETE FROM ponderacion_admin WHERE id_respuesta = %s' in delete_q
+        assert delete_params == (1,)
+        insert_q, insert_params = cursor.queries[2]
+        assert insert_params == [(1, 1, 0.0), (1, 2, 8.0)]
         assert conn.commit_called == 1
 
         resp2 = client.get('/admin/respuesta/1')

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -66,7 +66,11 @@ def test_vista_ranking_parametrized(monkeypatch):
     monkeypatch.setattr(app_module, "get_connection", lambda: conn)
     # mock factores count to ensure dynamic parameter is used
     expected_count = 7
-    monkeypatch.setattr(app_module, "get_factores", lambda: [object()] * expected_count)
+    monkeypatch.setattr(
+        app_module,
+        "get_factores",
+        lambda: [{"id": i + 1} for i in range(expected_count)],
+    )
 
     # reset cache
     cache.delete(RANKING_CACHE_KEY)
@@ -103,7 +107,11 @@ def test_vista_ranking_incompletas(monkeypatch):
     conn = DummyConnection(cursor)
     monkeypatch.setattr(db, "get_connection", lambda: conn)
     monkeypatch.setattr(app_module, "get_connection", lambda: conn)
-    monkeypatch.setattr(app_module, "get_factores", lambda: [object()] * 5)
+    monkeypatch.setattr(
+        app_module,
+        "get_factores",
+        lambda: [{"id": i + 1} for i in range(5)],
+    )
 
     cache.delete(RANKING_CACHE_KEY)
 
@@ -130,7 +138,11 @@ def test_ranking_cache_invalidation_after_ponderacion(monkeypatch):
     conn = DummyConnection(cursor)
     monkeypatch.setattr(db, "get_connection", lambda: conn)
     monkeypatch.setattr(app_module, "get_connection", lambda: conn)
-    monkeypatch.setattr(app_module, "get_factores", lambda: [object()] * 4)
+    monkeypatch.setattr(
+        app_module,
+        "get_factores",
+        lambda: [{"id": i + 1} for i in range(4)],
+    )
 
     cache.delete(RANKING_CACHE_KEY)
 
@@ -166,7 +178,7 @@ def test_vista_ranking_incluye_color(monkeypatch):
     conn = DummyConnection(cursor)
     monkeypatch.setattr(db, "get_connection", lambda: conn)
     monkeypatch.setattr(app_module, "get_connection", lambda: conn)
-    monkeypatch.setattr(app_module, "get_factores", lambda: [object()])
+    monkeypatch.setattr(app_module, "get_factores", lambda: [{"id": 1}])
 
     cache.delete(RANKING_CACHE_KEY)
 


### PR DESCRIPTION
## Summary
- Extend admin ponderacion saving to include all factors, defaulting missing ones to zero and replacing previous rows
- Test ponderacion saving now validates deletion and full-factor insert behavior
- Update ranking tests to use factor dictionaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689251a2af488322a05742bc4f67bfef