### PR TITLE
Switch admin weight column to decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Si deseas mantener un rango acotado, reemplaza la última línea por:
 
 Sustituye `<numero_maximo_de_factores>` por la cantidad máxima de factores que esperas manejar.
 
+### Cambiar `ponderacion_admin.peso_admin` a `DECIMAL(4,1)`
+
+Para evitar problemas de precisión con los valores de ponderación, la columna
+`peso_admin` ahora utiliza el tipo `DECIMAL(4,1)`. En instalaciones existentes
+puedes aplicar la migración con:
+
+```bash
+mysql -u <usuario> -p < database/migrate_peso_admin_decimal.sql
+```
+
+Este script crea una columna temporal, copia los valores existentes, elimina la
+columna original de tipo `FLOAT` y renombra la columna temporal.
+
 ## Caché de bloqueos
 
 El estado de bloqueo de cada formulario se almacena en memoria durante un

--- a/app.py
+++ b/app.py
@@ -686,9 +686,9 @@ def guardar_ponderacion():
                 flash("Cada ponderación debe estar entre 0 y 10.")
                 return redirect(url_for("detalle_respuesta", id_respuesta=id_respuesta))
 
-            peso = float(peso.quantize(Decimal("0.1")))
+            peso = peso.quantize(Decimal("0.1"))
         else:
-            peso = 0.0
+            peso = Decimal("0.0")
         ponderaciones.append((id_respuesta, id_factor, peso))
 
     g.cursor.execute(

--- a/database/migrate_peso_admin_decimal.sql
+++ b/database/migrate_peso_admin_decimal.sql
@@ -1,0 +1,12 @@
+-- Migration to change peso_admin from FLOAT to DECIMAL(4,1)
+ALTER TABLE ponderacion_admin
+    ADD COLUMN peso_admin_tmp DECIMAL(4,1);
+
+UPDATE ponderacion_admin
+    SET peso_admin_tmp = peso_admin;
+
+ALTER TABLE ponderacion_admin
+    DROP COLUMN peso_admin;
+
+ALTER TABLE ponderacion_admin
+    CHANGE COLUMN peso_admin_tmp peso_admin DECIMAL(4,1) NOT NULL;

--- a/database/modelo.sql
+++ b/database/modelo.sql
@@ -73,7 +73,7 @@ CREATE TABLE ponderacion_admin (
     id INT AUTO_INCREMENT PRIMARY KEY,
     id_respuesta INT NOT NULL,
     id_factor INT NOT NULL,
-    peso_admin FLOAT NOT NULL,  -- Puedes usar INT si prefieres solo enteros
+    peso_admin DECIMAL(4,1) NOT NULL,  -- Puedes usar INT si prefieres solo enteros
     FOREIGN KEY (id_respuesta) REFERENCES respuesta(id) ON DELETE CASCADE,
     FOREIGN KEY (id_factor) REFERENCES factor(id),
     UNIQUE (id_respuesta, id_factor)

--- a/tests/test_guardar_ponderacion.py
+++ b/tests/test_guardar_ponderacion.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import db
 import app as app_module
+from decimal import Decimal
 
 app = app_module.app
 
@@ -89,7 +90,7 @@ def test_guardar_ponderacion_ignora_global(monkeypatch):
             'nombre': 'F2',
             'descripcion': 'D',
             'valor_usuario': 3,
-            'peso_admin': 8.0,
+            'peso_admin': Decimal("8.0"),
         }
     ]
     fetchone = [{'id_respuesta': 1, 'nombre': 'N', 'apellidos': 'A', 'formulario': 'Form'}]
@@ -114,7 +115,10 @@ def test_guardar_ponderacion_ignora_global(monkeypatch):
         assert 'DELETE FROM ponderacion_admin WHERE id_respuesta = %s' in delete_q
         assert delete_params == (1,)
         insert_q, insert_params = cursor.queries[2]
-        assert insert_params == [(1, 1, 0.0), (1, 2, 8.0)]
+        assert insert_params == [
+            (1, 1, Decimal("0.0")),
+            (1, 2, Decimal("8.0")),
+        ]
         assert conn.commit_called == 1
 
         resp2 = client.get('/admin/respuesta/1')


### PR DESCRIPTION
## Summary
- define ponderacion_admin.peso_admin as DECIMAL(4,1)
- add migration script for converting existing FLOAT data
- store admin weights as Decimal and document migration steps

## Testing
- `pytest`
- `mysql < database/migrate_peso_admin_decimal.sql` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68925309e66c832288e1fc0a7e68df8e