### PR TITLE
Include color in ranking query

### DIFF
--- a/app.py
+++ b/app.py
@@ -751,6 +751,7 @@ def vista_ranking():
 
         ranking_query = """
             SELECT f.nombre,
+                   f.color,
                    SUM(pa.peso_admin * rd.valor_usuario) AS total
             FROM factor f
             JOIN ponderacion_admin pa ON f.id = pa.id_factor
@@ -763,7 +764,7 @@ def vista_ranking():
             JOIN respuesta r ON r.id = rc.id_respuesta AND r.bloqueado = 0
             JOIN respuesta_detalle rd
                 ON rd.id_respuesta = pa.id_respuesta AND rd.id_factor = f.id
-            GROUP BY f.id, f.nombre
+            GROUP BY f.id, f.nombre, f.color
             ORDER BY total DESC
         """
         g.cursor.execute(ranking_query, (count_factores,))

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -188,3 +188,7 @@ def test_vista_ranking_incluye_color(monkeypatch):
         resp = client.get("/admin/ranking")
         assert resp.status_code == 200
         assert b"background-color: #123456" in resp.data
+        # ensure the query requests the color column
+        ranking_query, _ = cursor.queries[3]
+        assert "f.color" in ranking_query
+        assert "GROUP BY f.id, f.nombre, f.color" in ranking_query


### PR DESCRIPTION
## Summary
- Include `f.color` in the ranking SQL query and group results by the color field
- Extend ranking tests to confirm query includes color and response renders it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68925d90bf008322b31bbc9825a90e82