### PR TITLE
Switch rankings to finalised responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -436,7 +436,7 @@ def administrar_formularios():
         FROM formulario f
         LEFT JOIN respuesta r
           ON r.id_formulario = f.id
-         AND r.bloqueado = 0
+         AND r.bloqueado = 1
         GROUP BY f.id, f.nombre
         ORDER BY f.id
         """
@@ -458,7 +458,7 @@ def eliminar_formulario(id):
     get_db()
 
     g.cursor.execute(
-        "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s AND bloqueado = 0",
+        "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s AND bloqueado = 1",
         (id,),
     )
     total_respuestas = g.cursor.fetchone()["total"]
@@ -480,7 +480,7 @@ def eliminar_formulario(id):
             expected = None
         if expected is not None:
             g.cursor.execute(
-                "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s AND bloqueado = 0",
+                "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s AND bloqueado = 1",
                 (id,),
             )
             total_actual = g.cursor.fetchone()["total"]
@@ -723,10 +723,14 @@ def vista_ranking():
     g.cursor.execute("SELECT COUNT(*) AS total FROM asignacion")
     total_asignados = g.cursor.fetchone()["total"]
 
-    g.cursor.execute("SELECT COUNT(*) AS total FROM respuesta WHERE bloqueado = 0")
+    g.cursor.execute("SELECT COUNT(*) AS total FROM respuesta WHERE bloqueado = 1")
     total_respuestas = g.cursor.fetchone()["total"]
 
+    g.cursor.execute("SELECT COUNT(*) AS total FROM respuesta WHERE bloqueado = 0")
+    total_desbloqueados = g.cursor.fetchone()["total"]
+
     pendientes = total_respuestas < total_asignados
+    hay_desbloqueados = total_desbloqueados > 0
 
     cached = cache.get(RANKING_CACHE_KEY)
     if cached is not None:
@@ -741,7 +745,7 @@ def vista_ranking():
             SELECT r.id AS id_respuesta
             FROM respuesta r
             LEFT JOIN ponderacion_admin p ON r.id = p.id_respuesta
-            WHERE r.bloqueado = 0
+            WHERE r.bloqueado = 1
             GROUP BY r.id
             HAVING COUNT(p.id_factor) < %s
         """
@@ -761,7 +765,7 @@ def vista_ranking():
                 GROUP BY id_respuesta
                 HAVING COUNT(id_factor) = %s
             ) rc ON pa.id_respuesta = rc.id_respuesta
-            JOIN respuesta r ON r.id = rc.id_respuesta AND r.bloqueado = 0
+            JOIN respuesta r ON r.id = rc.id_respuesta AND r.bloqueado = 1
             JOIN respuesta_detalle rd
                 ON rd.id_respuesta = pa.id_respuesta AND rd.id_factor = f.id
             GROUP BY f.id, f.nombre, f.color
@@ -789,6 +793,7 @@ def vista_ranking():
         total_respuestas=total_respuestas,
         incompletas=incompletas,
         estado_ranking=estado_ranking,
+        hay_desbloqueados=hay_desbloqueados,
     )
 
 

--- a/templates/admin_ranking.html
+++ b/templates/admin_ranking.html
@@ -37,6 +37,12 @@
       </div>
       {% endif %}
 
+      {% if hay_desbloqueados %}
+      <div class="alert alert-warning" role="alert">
+        Existen formularios sin bloquear; el ranking es provisional.
+      </div>
+      {% endif %}
+
       {% if incompletas %}
       <div class="alert alert-warning" role="alert">
         Existen respuestas con ponderaciones incompletas (ID: {{ incompletas|join(', ') }}). Estas respuestas fueron excluidas del ranking.

--- a/tests/test_admin_formularios.py
+++ b/tests/test_admin_formularios.py
@@ -116,7 +116,7 @@ def test_eliminar_formulario_invalida_cache(monkeypatch):
 
     assert cursor.queries == [
         (
-            "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s AND bloqueado = 0",
+            "SELECT COUNT(*) AS total FROM respuesta WHERE id_formulario = %s AND bloqueado = 1",
             (1,),
         ),
         ("DELETE FROM respuesta WHERE id_formulario = %s", (1,)),

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -18,7 +18,8 @@ class DummyCursor:
         self.execute_count = 0
         self.fetchone_results = fetchone_results if fetchone_results is not None else [
             {"total": 1},  # total_asignados
-            {"total": 1},  # total_respuestas
+            {"total": 1},  # total_respuestas bloqueadas
+            {"total": 0},  # total_respuestas desbloqueadas
         ]
         self.fetchall_results = fetchall_results if fetchall_results is not None else [
             [],  # incompletas_rows
@@ -83,12 +84,16 @@ def test_vista_ranking_parametrized(monkeypatch):
         assert b"Factor X" in resp.data
 
     # verify queries used placeholders
-    # queries: total_asignados, total_respuestas, incompletas, ranking
-    incompletas_query, incompletas_params = cursor.queries[2]
-    ranking_query, ranking_params = cursor.queries[3]
+    # queries: total_asignados, total_bloqueados, total_desbloqueados, incompletas, ranking
+    assert "bloqueado = 1" in cursor.queries[1][0]
+    assert "bloqueado = 0" in cursor.queries[2][0]
+    incompletas_query, incompletas_params = cursor.queries[3]
+    ranking_query, ranking_params = cursor.queries[4]
+    assert "r.bloqueado = 1" in incompletas_query
     assert "HAVING COUNT(p.id_factor) < %s" in incompletas_query
     assert incompletas_params == (expected_count,)
     assert "JOIN (" in ranking_query
+    assert "r.bloqueado = 1" in ranking_query
     assert "HAVING COUNT(id_factor) = %s" in ranking_query
     assert ranking_params == (expected_count,)
 
@@ -97,7 +102,8 @@ def test_vista_ranking_incompletas(monkeypatch):
     cursor = DummyCursor(
         fetchone_results=[
             {"total": 1},  # total_asignados
-            {"total": 1},  # total_respuestas
+            {"total": 1},  # total_bloqueados
+            {"total": 0},  # total_desbloqueados
         ],
         fetchall_results=[
             [{"id_respuesta": 42}],  # incompletas_rows
@@ -124,11 +130,37 @@ def test_vista_ranking_incompletas(monkeypatch):
         assert b"ID: 42" in resp.data
 
 
+def test_vista_ranking_alerta_desbloqueados(monkeypatch):
+    cursor = DummyCursor(
+        fetchone_results=[
+            {"total": 1},  # total_asignados
+            {"total": 1},  # total_bloqueados
+            {"total": 1},  # total_desbloqueados
+        ],
+        fetchall_results=[
+            [],
+            [{"nombre": "Factor X", "total": 5}],
+        ],
+    )
+    conn = DummyConnection(cursor)
+    monkeypatch.setattr(db, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_module, "get_factores", lambda: [{"id": 1}])
+
+    cache.delete(RANKING_CACHE_KEY)
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["is_admin"] = True
+        resp = client.get("/admin/ranking")
+        assert resp.status_code == 200
+        assert b"formularios sin bloquear" in resp.data
+
 def test_ranking_cache_invalidation_after_ponderacion(monkeypatch):
     fetchone_results = [
-        {"total": 1}, {"total": 1},
-        {"total": 1}, {"total": 1},
-        {"total": 1}, {"total": 1},
+        {"total": 1}, {"total": 1}, {"total": 0},
+        {"total": 1}, {"total": 1}, {"total": 0},
+        {"total": 1}, {"total": 1}, {"total": 0},
     ]
     fetchall_results = [
         [], [{"nombre": "Factor X", "total": 5}],
@@ -153,12 +185,12 @@ def test_ranking_cache_invalidation_after_ponderacion(monkeypatch):
         cursor.reset()
         resp = client.get("/admin/ranking")
         assert resp.status_code == 200
-        assert cursor.execute_count == 4
+        assert cursor.execute_count == 5
 
         cursor.reset()
         resp = client.get("/admin/ranking")
         assert resp.status_code == 200
-        assert cursor.execute_count == 2
+        assert cursor.execute_count == 3
 
         cursor.reset()
         resp = client.post("/admin/ponderar", data={"id_respuesta": "1", "ponderacion_1": "1"})
@@ -167,12 +199,12 @@ def test_ranking_cache_invalidation_after_ponderacion(monkeypatch):
         cursor.reset()
         resp = client.get("/admin/ranking")
         assert resp.status_code == 200
-        assert cursor.execute_count == 4
+        assert cursor.execute_count == 5
 
 
 def test_vista_ranking_incluye_color(monkeypatch):
     cursor = DummyCursor(
-        fetchone_results=[{"total": 1}, {"total": 1}],
+        fetchone_results=[{"total": 1}, {"total": 1}, {"total": 0}],
         fetchall_results=[[], [{"nombre": "Factor C", "total": 5, "color": "#123456"}]],
     )
     conn = DummyConnection(cursor)
@@ -189,6 +221,6 @@ def test_vista_ranking_incluye_color(monkeypatch):
         assert resp.status_code == 200
         assert b"background-color: #123456" in resp.data
         # ensure the query requests the color column
-        ranking_query, _ = cursor.queries[3]
+        ranking_query, _ = cursor.queries[4]
         assert "f.color" in ranking_query
         assert "GROUP BY f.id, f.nombre, f.color" in ranking_query


### PR DESCRIPTION
## Summary
- Rework ranking logic to use only blocked (`bloqueado = 1`) responses and flag any unlocked forms in the admin view.
- Show a warning in the ranking template when unblocked forms exist.
- Adjust admin form deletion and associated tests to count only blocked responses; expand ranking tests to cover unlocked form detection and new queries.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892656002bc8322b903c5162424105c