### PR TITLE
Wrap factor admin DB ops in single transaction

### DIFF
--- a/app.py
+++ b/app.py
@@ -554,35 +554,40 @@ def administrar_factores():
     factores = g.cursor.fetchall()
 
     if request.method == "POST":
-        # Actualizar los factores existentes
-        for f in factores:
-            nombre = request.form.get(f"nombre_{f['id']}")
-            descripcion = request.form.get(f"descripcion_{f['id']}")
-            color = request.form.get(f"color_{f['id']}")
-            g.cursor.execute(
-                "UPDATE factor SET nombre=%s, descripcion=%s, color=%s WHERE id=%s",
-                (nombre, descripcion, color, f["id"]),
-            )
+        try:
+            g.conn.start_transaction()
 
-        g.conn.commit()
+            # Actualizar los factores existentes
+            for f in factores:
+                nombre = request.form.get(f"nombre_{f['id']}")
+                descripcion = request.form.get(f"descripcion_{f['id']}")
+                color = request.form.get(f"color_{f['id']}")
+                g.cursor.execute(
+                    "UPDATE factor SET nombre=%s, descripcion=%s, color=%s WHERE id=%s",
+                    (nombre, descripcion, color, f["id"]),
+                )
 
-        # Insertar un nuevo factor si se proporcionan los campos
-        cache_invalidated = False
-        nuevo_nombre = request.form.get("nuevo_nombre")
-        nuevo_descripcion = request.form.get("nuevo_descripcion")
-        nuevo_color = request.form.get("nuevo_color")
-        if nuevo_nombre and nuevo_descripcion and nuevo_color:
-            g.cursor.execute(
-                "INSERT INTO factor (nombre, descripcion, color) VALUES (%s, %s, %s)",
-                (nuevo_nombre, nuevo_descripcion, nuevo_color),
-            )
+            # Insertar un nuevo factor si se proporcionan los campos
+            nuevo_nombre = request.form.get("nuevo_nombre")
+            nuevo_descripcion = request.form.get("nuevo_descripcion")
+            nuevo_color = request.form.get("nuevo_color")
+            nuevo_factor = False
+            if nuevo_nombre and nuevo_descripcion and nuevo_color:
+                g.cursor.execute(
+                    "INSERT INTO factor (nombre, descripcion, color) VALUES (%s, %s, %s)",
+                    (nuevo_nombre, nuevo_descripcion, nuevo_color),
+                )
+                nuevo_factor = True
+
             g.conn.commit()
-            invalidate_factores_cache()
-            cache_invalidated = True
-            flash("Nuevo factor agregado correctamente.")
+        except Exception:
+            g.conn.rollback()
+            flash("Error al actualizar los factores.")
+            return redirect(url_for("administrar_factores"))
 
-        if not cache_invalidated:
-            invalidate_factores_cache()
+        invalidate_factores_cache()
+        if nuevo_factor:
+            flash("Nuevo factor agregado correctamente.")
 
         flash("Factores actualizados correctamente.")
         return redirect(url_for("administrar_factores"))

--- a/tests/test_admin_factores.py
+++ b/tests/test_admin_factores.py
@@ -27,12 +27,19 @@ class DummyConnection:
     def __init__(self, cursor):
         self._cursor = cursor
         self.commit_called = 0
+        self.start_transaction_called = False
 
     def cursor(self, dictionary=True):
         return self._cursor
 
+    def start_transaction(self):
+        self.start_transaction_called = True
+
     def commit(self):
         self.commit_called += 1
+
+    def rollback(self):
+        pass
 
     def close(self):
         pass
@@ -77,4 +84,5 @@ def test_post_factores_incluye_color_en_queries(monkeypatch):
             ("Factor B", "Desc B", "#00ff00"),
         ),
     ]
-    assert conn.commit_called == 2
+    assert conn.start_transaction_called
+    assert conn.commit_called == 1


### PR DESCRIPTION
## Summary
- wrap factor updates and optional insert in a single transaction in `administrar_factores`
- invalidate factor cache after database changes and drop cache flag
- adjust admin factor tests for transactional logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926be4df9483229f3a34d5eda85457