### PR TITLE
Rename 404 handler

### DIFF
--- a/app.py
+++ b/app.py
@@ -813,7 +813,7 @@ def handle_bad_request(error):
 
 
 @app.errorhandler(404)
-def handle_bad_request(error):
+def handle_not_found(error):
     return render_template("error_404.html"), 404
 
 


### PR DESCRIPTION
## Summary
- Rename 404 error handler to `handle_not_found`
- Ensure no references remain to the old handler name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926e006ef083228d03a18bdbe14ee7