### PR TITLE
feat: add debug log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,18 @@ que altere el campo `bloqueado` debe llamar a `invalidate_bloqueo_cache` con
 el identificador del usuario y del formulario para eliminar la entrada
 correspondiente y evitar inconsistencias visibles.
 
+## Depuración de logs
+
+Para fines de desarrollo, la aplicación incluye una página que muestra el
+contenido del archivo de log (`static/logs/app.log`). Esta página está
+deshabilitada por defecto y no debe usarse en producción.
+
+1. Activa la característica estableciendo la variable de entorno
+   `ENABLE_DEBUG_LOGS=1` antes de ejecutar la aplicación.
+2. Inicia la aplicación normalmente (`python app.py`).
+3. Visita `http://localhost:5000/debug/logs_test` en tu navegador. El contenido
+   se actualiza cada pocos segundos consultando el endpoint `/debug/logs`.
+
+Recuerda desactivar la variable de entorno en entornos públicos para evitar
+exponer información sensible del sistema.
+

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ load_dotenv()
 from db import get_connection
 
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD")
+DEBUG_LOGS_ENABLED = os.getenv("ENABLE_DEBUG_LOGS") == "1"
 
 
 app = Flask(__name__)
@@ -136,6 +137,34 @@ def add_no_cache_headers(response):
         response.headers["Pragma"] = "no-cache"
         response.headers["Expires"] = "0"
     return response
+
+
+# ==============================
+# RUTAS DE DEPURACIÓN
+# ==============================
+
+
+@app.route("/debug/logs_test")
+def debug_logs_test():
+    if not DEBUG_LOGS_ENABLED:
+        return "Not found", 404
+    return render_template("logs_test.html")
+
+
+@app.route("/debug/logs")
+def debug_logs():
+    if not DEBUG_LOGS_ENABLED:
+        return "Not found", 404
+    log_path = os.path.join("static", "logs", "app.log")
+    if not os.path.exists(log_path):
+        return "", 200, {"Content-Type": "text/plain; charset=utf-8"}
+    with open(log_path, "r", encoding="utf-8") as f:
+        content = f.read()
+    return (
+        content,
+        200,
+        {"Content-Type": "text/plain; charset=utf-8", "Cache-Control": "no-cache"},
+    )
 
 
 # ==============================

--- a/templates/logs_test.html
+++ b/templates/logs_test.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Logs de aplicación</title>
+</head>
+<body>
+    <h1>Logs de aplicación</h1>
+    <pre id="log-output" style="background:#f0f0f0; padding:1em; overflow:auto;"></pre>
+    <script>
+    async function fetchLogs() {
+        try {
+            const resp = await fetch('/debug/logs');
+            if (resp.ok) {
+                const text = await resp.text();
+                document.getElementById('log-output').textContent = text;
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }
+    setInterval(fetchLogs, 2000);
+    fetchLogs();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose `/debug/logs` for viewing server logs and a companion `/debug/logs_test` page with auto-refreshing log display
- gate debug log routes behind `ENABLE_DEBUG_LOGS` environment variable
- document how to enable the log debugging page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689279574d2c8322b32eeb150d98022c