### PR TITLE
Align password form styling with other views

### DIFF
--- a/templates/formulario_password.html
+++ b/templates/formulario_password.html
@@ -5,20 +5,44 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Contraseña de Formulario</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
-<body>
-<div class="container py-5">
-    <h2>Ingrese la contraseña del formulario</h2>
-    {% if error %}
-    <div class="alert alert-danger">{{ error }}</div>
-    {% endif %}
-    <form method="post">
-        <div class="mb-3">
-            <label class="form-label">Contraseña</label>
-            <input type="password" class="form-control" name="password" required>
+<body class="login-background">
+    <div class="container py-5">
+        <div class="login-admin-card mx-auto">
+            <h2>Ingrese la contraseña del formulario</h2>
+
+            {% if error %}
+            <div class="alert alert-danger mb-4">{{ error }}</div>
+            {% endif %}
+
+            <form method="post">
+                <div class="mb-4">
+                    <label for="password" class="form-label">Contraseña</label>
+                    <input type="password" class="form-control" id="password" name="password" required>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary flex-fill">
+                        <i class="bi bi-arrow-left me-1"></i>Volver
+                    </a>
+                    <button type="submit" class="btn btn-primary flex-fill">
+                        <i class="bi bi-box-arrow-in-right me-1"></i>Acceder
+                    </button>
+                </div>
+            </form>
         </div>
-        <button type="submit" class="btn btn-primary">Acceder</button>
-    </form>
-</div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+    <div class="login-logos">
+        <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM">
+        <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES">
+        <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
+        <img src="{{ url_for('static', filename='img/Logo_ceide.png') }}" alt="Logo Extra 1">
+        <img src="{{ url_for('static', filename='img/logo_cfop.png') }}" alt="Logo Extra 2">
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle password entry page to match other views

## Testing
- `pytest` *(fails: test_post_factores_incluye_color_en_queries, test_guardar_respuesta_invalida_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68994c444b5483229cba7c3efe02fa0b