### PR TITLE
Add Bootstrap tooltips for factors

### DIFF
--- a/static/data/factores.json
+++ b/static/data/factores.json
@@ -1,0 +1,12 @@
+[
+  { "id": 1, "requisito": "Conjunto de conocimientos, habilidades y destrezas que se adquieren en la educación formal y a través de los diversos niveles o grados de escolarización que permiten desempeñarse en un ambiente laboral específico. Incluye también la formación académica en educación u otros aspectos relacionados con la didáctica, psicología educativa o materias afines." },
+  { "id": 2, "requisito": "Conjunto de actividades académicas que se cursan y acreditan las cuales permiten introducir, renovar y perfeccionar el conocimiento en materia de educación universitaria que favorecen el desempeño como formador." },
+  { "id": 3, "requisito": "Conjunto de premios, honores o menciones especiales que se han recibido en reconocimiento a la excelencia, logros o contribuciones en materia de formación docente y docencia universitaria." },
+  { "id": 4, "requisito": "Práctica adquirida a través del tiempo en el desempeño de una actividad profesional y académica en la educación universitaria, la cual puede determinarse en temporalidades (0-6 meses, 6 meses-1 año, 2 años, 3 años 5 o más años)." },
+  { "id": 5, "requisito": "Conjunto de conocimientos y hablidades específicas en temas, técnicas, metodologías o habilidades para desempeñarse como formador del profesorado universitario." },
+  { "id": 6, "requisito": "Se refiere a las contribuciones intelectuales que ha realizado en su campo de conocimiento aplicado a la formación docente tales como: artículos científicos en revistas académicas, ponencias, proyectos de investigación, autoría o coautoría de libros o capítulos." },
+  { "id": 7, "requisito": "Conjunto de rasgos y modos de comportamiento que conforman el carácter o la identidad de una persona o una comunidad. Para el caso del Ethos de un formador docente de la UNAM, éste estará conformado por el conocimiento de la institución (proyecto educativo), normatividad, valores y código de ética." },
+  { "id": 8, "requisito": "Predisposición cognitiva, emocional y conductual ante situaciones, personas o eventos que influye en la manera en que un individuo responde a su entorno." },
+  { "id": 9, "requisito": "Compromiso y resguardo de la documentación oficial, así como el cumplimiento de los procesos de gestión que la institución determine para la certificación de actividades de formación docente." },
+  { "id": 10, "requisito": "Resguardo de los equipos de cómputo, materiales didácticos y demás insumos que le sean proporcionados para el desarrollo de actividades para la formación y profesionalización docente." }
+]

--- a/static/js/factores.js
+++ b/static/js/factores.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('/static/data/factores.json')
+    .then(response => response.json())
+    .then(data => {
+      const requisitos = {};
+      data.forEach(f => {
+        requisitos[f.id] = f.requisito;
+      });
+      document.querySelectorAll('.factor-item').forEach(el => {
+        const id = el.getAttribute('data-factor-id');
+        const req = requisitos[id];
+        if (req) {
+          el.setAttribute('title', req);
+          el.setAttribute('data-bs-toggle', 'tooltip');
+        }
+      });
+      const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+      tooltipTriggerList.map(t => new bootstrap.Tooltip(t));
+    })
+    .catch(err => console.error('Error loading factors', err));
+});

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -101,7 +101,7 @@
                             {% for factor in factores %}
                             <tr>
                                 <td>
-                                    <span class="color-label" style="background-color: {{ factor.color or '#cccccc' }};">{{ factor.nombre }}</span>
+                                    <span class="color-label factor-item" data-factor-id="{{ factor.id }}" style="background-color: {{ factor.color or '#cccccc' }};">{{ factor.nombre }}</span>
                                     <span class="badge bg-secondary ms-1 dimension-badge" title="Dimensión">D{{ factor.dimension }}</span>
                                     <input type="hidden" name="factor_id_{{ loop.index }}" value="{{ factor.id }}">
                                 </td>
@@ -182,6 +182,7 @@
         });
     </script>
     <script src="{{ url_for('static', filename='js/dimensiones.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/factores.js') }}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- add static JSON with factor requisitos
- display factor requirement tooltips using Bootstrap

## Testing
- `pytest` *(fails: test_post_factores_incluye_color_en_queries, test_guardar_respuesta_invalida_cache)*

------
https://chatgpt.com/codex/tasks/task_e_689964e1b26c8322a4af9f0e26c44175