### PR TITLE
Store formulario passwords as hashes

### DIFF
--- a/database/migrate_formulario_password_db.sql
+++ b/database/migrate_formulario_password_db.sql
@@ -1,0 +1,4 @@
+-- Migration: replace password env key with password hash on formulario
+ALTER TABLE formulario
+    DROP COLUMN password_env_key,
+    ADD COLUMN password_hash VARCHAR(255) DEFAULT NULL AFTER requiere_password;

--- a/database/modelo.sql
+++ b/database/modelo.sql
@@ -16,7 +16,7 @@ CREATE TABLE formulario (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nombre VARCHAR(100) NOT NULL,
     requiere_password TINYINT(1) DEFAULT NULL,
-    password_env_key VARCHAR(50) DEFAULT NULL
+    password_hash VARCHAR(255) DEFAULT NULL -- Hash de la contraseña del formulario
 );
 
 -- Tabla de asignación usuario-formulario

--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -25,7 +25,7 @@
                             <th>ID</th>
                             <th>Nombre</th>
                             <th>Protección</th>
-                            <th>Clave ENV</th>
+                            <th>Hash</th>
                             <th>Respuestas</th>
                             <th>Acciones</th>
                         </tr>
@@ -38,7 +38,7 @@
                             <td>
                                 <form method="POST" action="{{ url_for('administrar_formularios') }}" class="small" style="min-width:280px;">
                                     <input type="hidden" name="id_formulario" value="{{ f.id }}">
-                                    <input type="hidden" name="current_password_env_key" value="{{ f.password_env_key or '' }}">
+                                    <input type="hidden" name="current_password_hash" value="{{ f.password_hash or '' }}">
                                     <div class="d-flex align-items-center gap-2 flex-wrap">
                                         <div class="form-check form-switch mb-0">
                                             <input class="form-check-input" type="checkbox" name="requiere_password" {% if f.requiere_password %}checked{% endif %}>
@@ -49,7 +49,7 @@
                                     </div>
                                     <div class="form-text mt-1">
                                         {% if f.requiere_password %}
-                                            {% if f.password_env_key %}Deja en blanco para mantener la contraseña actual.{% else %}Establece una contraseña para activar la protección.{% endif %}
+                                            {% if f.password_hash %}Deja en blanco para mantener la contraseña actual.{% else %}Establece una contraseña para activar la protección.{% endif %}
                                         {% else %}
                                             Marca el switch y proporciona una contraseña para activar.
                                         {% endif %}
@@ -57,8 +57,8 @@
                                 </form>
                             </td>
                             <td class="text-center align-middle">
-                                {% if f.password_env_key %}
-                                    <code class="small">{{ f.password_env_key }}</code>
+                                {% if f.password_hash %}
+                                    <code class="small">{{ f.password_hash }}</code>
                                 {% else %}
                                     <span class="text-muted small">—</span>
                                 {% endif %}
@@ -96,7 +96,7 @@
                 </div>
                 <div class="mb-3">
                     <input type="password" name="password" class="form-control" placeholder="Contraseña (requerida si proteges)" autocomplete="new-password">
-                    <div class="form-text">Si activas la protección, debes ingresar una contraseña. Se almacenará en variable de entorno segura.</div>
+                    <div class="form-text">Si activas la protección, debes ingresar una contraseña. Se almacenará de forma segura.</div>
                 </div>
                 <button class="btn btn-success" type="submit"><i class="bi bi-lock-fill me-1"></i>Crear Formulario</button>
             </form>


### PR DESCRIPTION
## Summary
- replace `password_env_key` with `password_hash` column via new migration and model update
- use password hashes instead of environment variables throughout app and admin UI
- adjust tests for hashed password workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a55f85b22883228954f078b0a89540