### PR TITLE
Handle partial form submissions

### DIFF
--- a/tests/test_guardar_respuesta.py
+++ b/tests/test_guardar_respuesta.py
@@ -117,3 +117,44 @@ def test_guardar_respuesta_invalida_cache(monkeypatch):
     assert conn.start_transaction_called
     assert conn.commit_called
     assert cache.get(bloqueo_key(1, 2)) is True
+
+
+def test_guardar_respuesta_incompleta(monkeypatch):
+    cursor, conn = create_dummy(monkeypatch)
+    monkeypatch.setattr(app_module, "get_factores", lambda: [{"id": 1}, {"id": 2}])
+
+    cache.clear()
+    cache.set(bloqueo_key(1, 2), False, timeout=app_module.BLOQUEO_CACHE_TTL)
+
+    data = {
+        "usuario_id": "1",
+        "formulario_id": "2",
+        "nombre": "N",
+        "apellidos": "A",
+        "cargo": "C",
+        "dependencia": "D",
+        # Solo se envía un factor de dos
+        "factor_id_1": "1",
+        "valor_1": "1",
+    }
+
+    with app.test_client() as client:
+        resp = client.post("/guardar_respuesta", data=data)
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/formulario/1")
+        with client.session_transaction() as sess:
+            flashes = sess.get("_flashes", [])
+        assert (
+            "message",
+            "Respuestas incompletas; se guardó el progreso sin bloquear",
+        ) in flashes
+        assert cache.get(bloqueo_key(1, 2)) is None
+
+    assert len(cursor.queries) == 4
+    assert "UPDATE usuario" in cursor.queries[0][0]
+    assert "SELECT id FROM respuesta" in cursor.queries[1][0]
+    assert "INSERT INTO respuesta" in cursor.queries[2][0]
+    assert cursor.queries[2][1] == (1, 2, 0)
+    assert "INSERT INTO respuesta_detalle" in cursor.queries[3][0]
+    assert conn.start_transaction_called
+    assert conn.commit_called


### PR DESCRIPTION
## Summary
- Allow `guardar_respuesta` to accept partial factor data and track completion
- Save incomplete forms without blocking and redirect with a flash notice
- Test partial submissions to ensure progress is saved and unblocked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcdbe80ad88322baeb22446a8acb52