### PR TITLE
Show confirmation message based on form lock status

### DIFF
--- a/app.py
+++ b/app.py
@@ -640,14 +640,14 @@ def guardar_respuesta():
     invalidate_ranking_cache()
 
     if not completo:
-        flash("Respuestas incompletas; se guardó el progreso sin bloquear")
         app.logger.info(
             "Respuesta incompleta usuario=%s formulario=%s",
             id_usuario,
             id_formulario,
         )
         if exit_redirect:
-            return redirect(url_for("index"))
+            return render_template("confirmacion.html", bloqueado=False)
+        flash("Respuestas incompletas; se guardó el progreso sin bloquear")
         return redirect(url_for("mostrar_formulario", id_usuario=id_usuario))
 
     if exit_redirect:
@@ -656,13 +656,13 @@ def guardar_respuesta():
             id_usuario,
             id_formulario,
         )
-        return redirect(url_for("index"))
-    app.logger.info(
-        "Respuesta guardada usuario=%s formulario=%s",
-        id_usuario,
-        id_formulario,
-    )
-    return render_template("confirmacion.html")
+    else:
+        app.logger.info(
+            "Respuesta guardada usuario=%s formulario=%s",
+            id_usuario,
+            id_formulario,
+        )
+    return render_template("confirmacion.html", bloqueado=True)
 
 
 @app.route("/admin/login", methods=["GET", "POST"])

--- a/templates/confirmacion.html
+++ b/templates/confirmacion.html
@@ -17,8 +17,13 @@
                 <i class="bi bi-check-lg"></i>
             </div>
             
+            {% if bloqueado %}
             <h3>¡Formulario enviado y bloqueado!</h3>
             <p>Agradecemos tu participación en este ejercicio. Los resultados serán presentados en la sesión ordinaria de la red universitaria de formación docente.</p>
+            {% else %}
+            <h3>Progreso guardado; el formulario sigue abierto</h3>
+            <p>Puedes volver más tarde para completar el formulario.</p>
+            {% endif %}
 
             <a href="{{ url_for('index') }}" class="btn btn-primary">
                 <i class="bi bi-house me-1"></i>Volver a la página principal


### PR DESCRIPTION
## Summary
- Make confirmation template dynamic to display blocked vs progress saved messages
- Pass `bloqueado` flag from form submission route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcdeb4557c83228904ddc0e83796d6