### PR TITLE
Reemplaza contenedor de logos y ajusta estilos de inicio

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -27,47 +27,6 @@
   vertical-align: middle;
 }
 
-/* Nueva barra de logos */
-.logos-bar {
-  --bar-bg: rgba(255,255,255,0.82);
-  --bar-border: rgba(0,0,0,0.08);
-  position: fixed;
-  inset: auto 0 0 0; /* bottom full width */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 2.2rem;
-  padding: .65rem 1.5rem .55rem;
-  backdrop-filter: blur(10px) saturate(140%);
-  -webkit-backdrop-filter: blur(10px) saturate(140%);
-  background: linear-gradient(90deg,var(--bar-bg),rgba(255,255,255,0.78));
-  border-top: 1px solid var(--bar-border);
-  z-index: 1040;
-  box-shadow: 0 -2px 8px -2px rgba(0,0,0,0.12);
-}
-.logos-bar img {
-  max-height: 50px;
-  width: auto;
-  object-fit: contain;
-  filter: drop-shadow(0 1px 2px rgba(0,0,0,.25));
-  transition: transform .28s ease, filter .28s ease;
-  opacity: .92;
-}
-.logos-bar img:hover {
-  transform: translateY(-4px) scale(1.05);
-  filter: drop-shadow(0 4px 10px rgba(0,0,0,.35));
-  opacity: 1;
-}
-@media (max-width: 900px) {
-  .logos-bar { gap: 1.2rem; padding:.55rem 1rem; }
-  .logos-bar img { max-height: 42px; }
-}
-@media (max-width: 640px) {
-  .logos-bar { gap: .75rem; padding:.45rem .75rem; }
-  .logos-bar img { max-height: 36px; }
-}
-/* Ocultar barra de logos mientras haya modal abierto para evitar distracción */
-body.modal-open .logos-bar { opacity: 0; pointer-events:none; transition: opacity .25s ease; }
 .row-highlight {
   animation: pulseRow 2.2s ease-in-out;
   position: relative;
@@ -912,6 +871,7 @@ body.modal-open .login-logos {
   position: fixed;
   bottom: 2rem;
   left: 2rem;
+  right: auto;
   display: flex;
   align-items: center;
   gap: 1rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -229,13 +229,13 @@
         </div>
     </div>
 
-    <!-- Barra de logos fija -->
-    <div class="logos-bar" role="contentinfo" aria-label="Logotipos institucionales">
-        <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="UNAM" loading="lazy">
-        <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Planeación" loading="lazy">
-        <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="FES" loading="lazy">
-        <img src="{{ url_for('static', filename='img/logo_unam_negro.png') }}" alt="UNAM versión monocromo" loading="lazy">
-        <img src="{{ url_for('static', filename='img/logo_planeacion_negro.png') }}" alt="Planeación monocromo" loading="lazy">
+    <!-- Logos institucionales -->
+    <div class="login-logos">
+        <img src="{{ url_for('static', filename='img/logo_unam.png') }}" alt="Logo UNAM" style="width: 5rem; height: auto;">
+        <img src="{{ url_for('static', filename='img/Logo_ceide.png') }}" alt="Logo CEIDE">
+        <img src="{{ url_for('static', filename='img/logo_cfop.png') }}" alt="Logo CFOP">
+        <img src="{{ url_for('static', filename='img/logo_fes.png') }}" alt="Logo FES" style="width: 4.4rem; height: auto;">
+        <img src="{{ url_for('static', filename='img/logo_planeacion.png') }}" alt="Logo Planeación">
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Sustituye `logos-bar` por `login-logos` en la página de inicio reutilizando los logotipos del acceso de administrador
- Ajusta la posición del bloque de logotipos en el CSS y elimina estilos obsoletos de `.logos-bar`

## Testing
- `pytest`
- `curl -sS http://127.0.0.1:5000/ | sed -n '233,240p'`


------
https://chatgpt.com/codex/tasks/task_e_68c1d83865b483228d0164c8cde3f9e8