### PR TITLE
Add admin form response reset control

### DIFF
--- a/templates/admin_formularios.html
+++ b/templates/admin_formularios.html
@@ -72,6 +72,11 @@
                                 {% else %}
                                 <span class="text-muted small me-1">Sin usuario</span>
                                 {% endif %}
+                                <form method="POST" action="{{ url_for('reiniciar_respuestas_formulario', id_formulario=f.id) }}" style="display:inline;">
+                                    <button type="submit" class="btn btn-sm btn-outline-warning me-1" onclick="return confirm('¿Reiniciar las respuestas de este formulario? Esta acción no modifica los datos del usuario.');">
+                                        <i class="bi bi-arrow-counterclockwise me-1"></i>Reiniciar
+                                    </button>
+                                </form>
                                 <form method="POST" action="{{ url_for('eliminar_formulario', id=f.id) }}" style="display:inline;">
                                     <button type="submit" class="btn btn-sm btn-danger">
                                         <i class="bi bi-trash me-1"></i>Eliminar


### PR DESCRIPTION
## Summary
- add an admin endpoint to reset the responses of a single formulario without touching user data
- expose the reset action in the admin formulario list with a confirmation prompt
- extend the admin formulario tests to cover the new reset flow and enhance the dummy cursor helper

## Testing
- MAINTENANCE=0 pytest

------
https://chatgpt.com/codex/tasks/task_e_68d344f4b5f4832297b6f47219d3c6fd