### PR TITLE
Agregar vista de logs para administrador

### DIFF
--- a/templates/_admin_nav.html
+++ b/templates/_admin_nav.html
@@ -9,6 +9,7 @@
         <li class="nav-item"><a class="nav-link {% if request.endpoint=='administrar_formularios' %}active{% endif %}" href="{{ url_for('administrar_formularios') }}"><i class="bi bi-ui-checks-grid me-1"></i>Formularios</a></li>
         <li class="nav-item"><a class="nav-link {% if request.endpoint=='administrar_factores' %}active{% endif %}" href="{{ url_for('administrar_factores') }}"><i class="bi bi-pencil-square me-1"></i>Factores</a></li>
         <li class="nav-item"><a class="nav-link {% if request.endpoint=='vista_ranking' %}active{% endif %}" href="{{ url_for('vista_ranking') }}"><i class="bi bi-bar-chart-line me-1"></i>Ranking</a></li>
+        <li class="nav-item"><a class="nav-link {% if request.endpoint=='admin_logs' %}active{% endif %}" href="{{ url_for('admin_logs') }}"><i class="bi bi-clipboard-data me-1"></i>Logs</a></li>
       </ul>
       <div class="d-flex align-items-center gap-2">
         <span class="badge bg-secondary d-none d-md-inline">Admin</span>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -47,6 +47,10 @@
                                 class="nav-link {% if request.endpoint=='vista_ranking' %}active{% endif %}"
                                 href="{{ url_for('vista_ranking') }}"><i
                                     class="bi bi-bar-chart-line me-1"></i>Ranking</a></li>
+                        <li class="nav-item"><a
+                                class="nav-link {% if request.endpoint=='admin_logs' %}active{% endif %}"
+                                href="{{ url_for('admin_logs') }}"><i class="bi bi-clipboard-data me-1"></i>Logs</a>
+                        </li>
                         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_logout') }}"><i
                                     class="bi bi-box-arrow-right me-1"></i>Cerrar sesión</a></li>
                     </ul>

--- a/templates/admin_logs.html
+++ b/templates/admin_logs.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Logs de actividad</title>
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='img/unam_ico.ico') }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+</head>
+
+<body class="global-bg">
+    <div class="container py-5">
+        {% include '_admin_nav.html' %}
+        <div class="admin-container">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                <h2 class="mb-0">Registro de actividad</h2>
+                <span class="badge bg-secondary">{{ logs|length }} registros</span>
+            </div>
+            <p class="text-muted small mb-4">
+                Se muestran los últimos {{ limit }} eventos registrados en texto plano para mantener un historial ligero.
+            </p>
+            {% if logs %}
+            <div class="table-responsive">
+                <table class="table table-sm table-hover table-striped align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">Fecha</th>
+                            <th scope="col">Hora</th>
+                            <th scope="col">Nivel</th>
+                            <th scope="col">Actor</th>
+                            <th scope="col">Formulario</th>
+                            <th scope="col">Detalle</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for log in logs %}
+                        <tr>
+                            <td class="text-nowrap">{{ log.fecha }}</td>
+                            <td class="text-nowrap">{{ log.hora }}</td>
+                            <td class="text-nowrap">
+                                <span class="badge {% if log.nivel == 'ERROR' %}bg-danger{% elif log.nivel == 'WARNING' %}bg-warning text-dark{% elif log.nivel == 'INFO' %}bg-info text-dark{% else %}bg-secondary{% endif %}">
+                                    {{ log.nivel }}
+                                </span>
+                            </td>
+                            <td>{{ log.actor }}</td>
+                            <td class="text-nowrap">{{ log.formulario or '—' }}</td>
+                            <td><code class="small text-break d-block">{{ log.mensaje }}</code></td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <div class="alert alert-info">No hay registros disponibles por el momento.</div>
+            {% endif %}
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- agregar utilidades para leer el archivo de registros y exponer la ruta /admin/logs con la información reciente
- actualizar la navegación del panel para incluir el acceso a la nueva vista
- crear la plantilla del listado de logs respetando el estilo existente

## Testing
- MAINTENANCE=0 pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34b6224cc83228ffbc2710c60fa6e